### PR TITLE
Add .gitignore for uploads, editors, and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# WordPress uploads
+wp-content/uploads/
+
+# Node dependencies
+node_modules/
+
+# Composer dependencies
+vendor/
+
+# Editor swap files
+*.swp
+*.swo
+*~
+
+# Operating system files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Temporary files
+tmp/
+temp/


### PR DESCRIPTION
## Summary
- add repository-wide `.gitignore` to avoid tracking common development artifacts

## Testing
- `composer test` *(fails: command "test" is not defined)*
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687b6f4c884083299eda5cc55f244eb7