### PR TITLE
Add initial third-generation theme scaffolding

### DIFF
--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Theme functions and definitions
+ */
+
+function newmr_theme_setup() {
+    add_theme_support( 'wp-block-styles' );
+}
+add_action( 'after_setup_theme', 'newmr_theme_setup' );

--- a/generations/third/newmr-theme/style.css
+++ b/generations/third/newmr-theme/style.css
@@ -1,0 +1,9 @@
+/*
+Theme Name: NewMR Theme
+Author: NewMR
+Description: Scaffolding for the third generation theme.
+Version: 0.1.0
+Requires at least: 6.0
+Tested up to: 6.5
+Requires PHP: 7.4
+*/

--- a/generations/third/newmr-theme/theme.json
+++ b/generations/third/newmr-theme/theme.json
@@ -1,0 +1,6 @@
+{
+    "version": 2,
+    "settings": {
+        "appearanceTools": true
+    }
+}


### PR DESCRIPTION
## Summary
- add `newmr-theme` folder with starter files for the third generation
- include a theme header in `style.css`
- add a simple `functions.php`
- configure `theme.json` with minimal block settings

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687b744893508329a570b2dc3d319f69