### PR TITLE
Add minimal third-gen plugin skeleton

### DIFF
--- a/generations/third/newmr-plugin/newmr-plugin.php
+++ b/generations/third/newmr-plugin/newmr-plugin.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Plugin Name: NewMR Plugin
+ * Plugin URI: https://example.com/
+ * Description: Skeleton plugin for the third generation of NewMR.
+ * Version: 0.1.0
+ * Author: NewMR Team
+ * Author URI: https://example.com/
+ * License: GPL2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Initialize the plugin.
+ */
+function newmr_plugin_init() {
+    // TODO: add initialization code.
+}
+add_action( 'init', 'newmr_plugin_init' );
+
+/**
+ * Placeholder for plugin activation hook.
+ */
+function newmr_plugin_activate() {
+    // TODO: add activation code.
+}
+register_activation_hook( __FILE__, 'newmr_plugin_activate' );
+
+/**
+ * Placeholder for plugin deactivation hook.
+ */
+function newmr_plugin_deactivate() {
+    // TODO: add deactivation code.
+}
+register_deactivation_hook( __FILE__, 'newmr_plugin_deactivate' );


### PR DESCRIPTION
## Summary
- add initial plugin file under `generations/third/newmr-plugin`

## Testing
- `composer lint` *(fails: Command "lint" is not defined)*
- `composer test` *(fails: Command "test" is not defined)*
- `npm run lint` *(fails: could not read package.json)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687b7448e7b08329bda0a594ce3b6f8b