### PR TITLE
Add end-to-end testing setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,16 @@ Run the provided Docker Compose configuration to start WordPress with the third-
 docker compose up
 ```
 
+## End-to-End Tests
+
+Basic tests live under `e2e/` and expect the Docker environment to be running.
+Start the containers and then execute the tests from the theme directory:
+
+```bash
+docker compose up -d
+cd generations/third/newmr-theme
+npm run e2e
+```
+
+Set `BASE_URL` if the site is accessible at a different address.
+

--- a/e2e/homepage.test.js
+++ b/e2e/homepage.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import {test} from 'node:test';
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:8000';
+
+async function fetchText(url) {
+  const res = await fetch(url);
+  assert.equal(res.status, 200);
+  return res.text();
+}
+
+test('homepage loads', async () => {
+  const text = await fetchText(baseUrl);
+  assert.match(text, /wordpress/i);
+});
+
+test('navigate to sample page', async () => {
+  const text = await fetchText(`${baseUrl}/sample-page/`);
+  assert.match(text, /sample page/i);
+});

--- a/generations/third/newmr-theme/package.json
+++ b/generations/third/newmr-theme/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "vite build",
     "watch": "vite",
-    "lint": "eslint . --ext js,jsx || true && prettier --check ."
+    "lint": "eslint . --ext js,jsx || true && prettier --check .",
+    "test": "echo \"No JS tests\"",
+    "e2e": "node --test ../../../e2e"
   },
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Summary
- add `e2e/` folder with simple Node tests
- expose `e2e` npm script in the theme
- document how to run the tests in `AGENTS.md`

## Testing
- `composer test` *(fails: PHPCS errors)*
- `npm run lint` in `generations/third/newmr-theme`
- `npm test` in `generations/third/newmr-theme`
- `npm run e2e` in `generations/third/newmr-theme` *(fails: could not connect to localhost)*

------
https://chatgpt.com/codex/tasks/task_b_687b7c53828c8329b5827d9c983a6ea6