### PR TITLE
Add documentation on using Tailwind UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Navigate to [http://localhost:8000](http://localhost:8000) to access the site. A
 ## Building the Theme
 Run `npm install` inside `generations/third/newmr-theme` and then `npm run build` to bundle assets. Use `npm run watch` during development.
 
+## Tailwind UI Resources
+The repository includes a licensed copy of [Tailwind UI](https://tailwindui.com) under the `tailwindui/` directory. These components and templates are used for the third-generation UI. See `generations/third/TailwindUI.md` for usage instructions.
+
 
 ## Tests and Linting
 

--- a/generations/third/README.md
+++ b/generations/third/README.md
@@ -1,1 +1,7 @@
 # Third Generation
+
+This folder contains the in-progress rewrite of the NewMR WordPress toolkit. All theme and plugin development for the upcoming release happens here.
+
+## Tailwind UI
+
+The UI for this generation is being built with Tailwind CSS. A licensed copy of Tailwind UI is included under `../../tailwindui/` for convenience. See [TailwindUI.md](./TailwindUI.md) for details on how to browse and reuse these components and templates.

--- a/generations/third/TailwindUI.md
+++ b/generations/third/TailwindUI.md
@@ -1,0 +1,40 @@
+# Using Tailwind UI
+
+The third-generation NewMR UI is built with [Tailwind CSS](https://tailwindcss.com) and makes heavy use of components from Tailwind UI. This repository includes a local copy of the Tailwind UI kit and two full templates for reference. These resources live under the top-level `tailwindui/` directory.
+
+## Included resources
+
+- `tailwindui/ui-kit` – Standalone React components that can be copied into the theme or used as inspiration when creating Gutenberg blocks and other UI pieces.
+- `tailwindui/templates/compass` – The "Compass" site template.
+- `tailwindui/templates/keynote` – The "Keynote" site template.
+
+Both templates are provided strictly for design inspiration. They are full Next.js sites demonstrating how the components fit together. Browse the source under their respective `src/` directories to see complete layouts, navigation patterns, and interactive widgets.
+
+## Workflow
+
+1. **Install theme dependencies**
+   
+   ```bash
+   cd generations/third/newmr-theme
+   npm install
+   ```
+
+2. **Run the development server**
+
+   ```bash
+   npm run watch
+   ```
+
+   This compiles the theme's assets with Vite and enables hot reloading. Edit files inside `newmr-theme` and refresh the browser to see updates.
+
+3. **Copy components from the UI kit**
+
+   Find a desired component in `tailwindui/ui-kit/` and copy the JSX into your plugin or theme. The components expect Tailwind CSS classes and may rely on [Headless UI](https://headlessui.dev). Install any additional npm packages as needed.
+
+4. **Reference the templates for layout ideas**
+
+   The Compass and Keynote templates showcase complete layouts that are very similar to what NewMR needs. Open the `README.md` inside each template for instructions on running the template locally. Studying these examples is recommended before building new pages.
+
+## Notes
+
+Tailwind UI is a commercial product. The files included here are licensed to NewMR and must not be redistributed. Only commit derivatives or components that fall within the license terms.

--- a/generations/third/newmr-theme/theme.json
+++ b/generations/third/newmr-theme/theme.json
@@ -1,6 +1,6 @@
 {
-    "version": 2,
-    "settings": {
-        "appearanceTools": true
-    }
+  "version": 2,
+  "settings": {
+    "appearanceTools": true
+  }
 }


### PR DESCRIPTION
## Summary
- document how to use the included Tailwind UI templates and component kit
- link to the new TailwindUI doc from the third generation README and repo root README
- fix `theme.json` formatting

## Testing
- `composer lint`
- `composer test` *(fails: requires WordPress test setup)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687b89d0e40c8329960fa7fff6a4129d