### PR TITLE
Port custom post types to third generation

### DIFF
--- a/generations/third/newmr-plugin/newmr-plugin.php
+++ b/generations/third/newmr-plugin/newmr-plugin.php
@@ -16,24 +16,192 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Initialize the plugin.
+ * Constants for custom rewrite endpoints.
  */
-function newmr_plugin_init() {
-	register_post_type(
-		'newmr_item',
-		array(
-			'public' => true,
-			'label'  => 'NewMR Item',
-		)
-	);
+if ( ! defined( 'EP_EVENT' ) ) {
+		define( 'EP_EVENT', 8192 );
 }
-add_action( 'init', 'newmr_plugin_init' );
+
+/**
+ * Register all custom post types and taxonomies.
+ */
+function newmr_register_post_types() {
+		register_post_type(
+			'booth',
+			array(
+				'labels'            => array(
+					'name'          => __( 'eXhibition', 'newmr' ),
+					'singular_name' => __( 'Booth', 'newmr' ),
+					'add_new_item'  => __( 'Add New Booth', 'newmr' ),
+					'edit_item'     => __( 'Edit Booth', 'newmr' ),
+				),
+				'public'            => true,
+				'has_archive'       => true,
+				'show_in_nav_menus' => false,
+				'menu_position'     => 15,
+				'menu_icon'         => 'dashicons-visibility',
+				'supports'          => array( 'title', 'editor', 'page-attributes' ),
+				'rewrite'           => array(
+					'slug'       => 'exhibition',
+					'with_front' => false,
+				),
+			)
+		);
+
+		register_post_type(
+			'advert',
+			array(
+				'labels'            => array(
+					'name'          => __( 'Adverts', 'newmr' ),
+					'singular_name' => __( 'Advert', 'newmr' ),
+					'add_new_item'  => __( 'Add New Advert', 'newmr' ),
+					'edit_item'     => __( 'Edit Advert', 'newmr' ),
+				),
+				'public'            => true,
+				'show_in_nav_menus' => false,
+				'menu_position'     => 16,
+				'menu_icon'         => 'dashicons-star-filled',
+				'supports'          => array( 'title', 'editor', 'page-attributes' ),
+			)
+		);
+
+		register_post_type(
+			'event',
+			array(
+				'labels'             => array(
+					'name'          => __( 'Events', 'newmr' ),
+					'singular_name' => __( 'Event', 'newmr' ),
+					'add_new_item'  => __( 'Add New Event', 'newmr' ),
+					'edit_item'     => __( 'Edit Event', 'newmr' ),
+				),
+				'public'             => true,
+				'publicly_queryable' => true,
+				'query_var'          => true,
+				'show_in_nav_menus'  => true,
+				'menu_position'      => 17,
+				'menu_icon'          => 'dashicons-calendar',
+				'hierarchical'       => true,
+				'supports'           => array( 'title', 'editor', 'page-attributes', 'thumbnail', 'revisions', 'shortlinks' ),
+				'rewrite'            => false,
+			)
+		);
+
+		register_post_type(
+			'presentation',
+			array(
+				'labels'            => array(
+					'name'          => __( 'Presentations', 'newmr' ),
+					'singular_name' => __( 'Presentation', 'newmr' ),
+					'add_new_item'  => __( 'Add New Presentation', 'newmr' ),
+					'edit_item'     => __( 'Edit Presentation', 'newmr' ),
+				),
+				'public'            => true,
+				'show_in_nav_menus' => false,
+				'menu_position'     => 18,
+				'menu_icon'         => 'dashicons-video-alt3',
+				'supports'          => array( 'title', 'editor', 'page-attributes', 'revisions', 'shortlinks' ),
+				'rewrite'           => array(
+					'slug'       => 'presentations',
+					'with_front' => false,
+				),
+				'taxonomies'        => array( 'topic' ),
+			)
+		);
+
+		register_taxonomy(
+			'topic',
+			'presentation',
+			array(
+				'labels'            => array(
+					'name'                       => __( 'Topics', 'newmr' ),
+					'singular_name'              => __( 'Topic', 'newmr' ),
+					'all_items'                  => __( 'All Topics', 'newmr' ),
+					'edit_item'                  => __( 'Edit Topic', 'newmr' ),
+					'view_item'                  => __( 'View Topic', 'newmr' ),
+					'update_item'                => __( 'Update Topic', 'newmr' ),
+					'add_new_item'               => __( 'Add New Topic', 'newmr' ),
+					'new_item_name'              => __( 'New Topic Name', 'newmr' ),
+					'search_items'               => __( 'Search Topics', 'newmr' ),
+					'popular_items'              => __( 'Popular Topics', 'newmr' ),
+					'separate_items_with_commas' => __( 'Separate topics with commas', 'newmr' ),
+					'add_or_remove_items'        => __( 'Add or remove topics', 'newmr' ),
+					'choose_from_most_used'      => __( 'Choose from the most used topics', 'newmr' ),
+					'not_found'                  => __( 'No topics found', 'newmr' ),
+				),
+				'show_admin_column' => true,
+				'rewrite'           => array(
+					'slug'       => 'topic',
+					'with_front' => false,
+				),
+			)
+		);
+
+		register_post_type(
+			'person',
+			array(
+				'labels'            => array(
+					'name'          => __( 'People', 'newmr' ),
+					'singular_name' => __( 'Person', 'newmr' ),
+					'add_new_item'  => __( 'Add New Person', 'newmr' ),
+					'edit_item'     => __( 'Edit Person', 'newmr' ),
+				),
+				'public'            => true,
+				'has_archive'       => true,
+				'show_in_nav_menus' => false,
+				'menu_position'     => 19,
+				'menu_icon'         => 'dashicons-id',
+				'supports'          => array( 'title', 'editor', 'thumbnail', 'shortlinks' ),
+				'rewrite'           => array(
+					'slug'       => 'people',
+					'with_front' => false,
+				),
+			)
+		);
+
+		add_rewrite_rule(
+			'^play-again/([^/]*)/([^/]*)/?$',
+			'index.php?pagename=play-again&one=$matches[1]&two=$matches[2]',
+			'top'
+		);
+		add_rewrite_rule(
+			'^play-again/([^/]*)/?$',
+			'index.php?pagename=play-again&one=$matches[1]',
+			'top'
+		);
+
+		add_rewrite_tag( '%one%', '([^&]+)' );
+		add_rewrite_tag( '%two%', '([^&]+)' );
+
+		add_rewrite_tag( '%event%', '(.?.+?)', 'event=' );
+		add_rewrite_tag( '%eyear%', '([0-9]{4})' );
+		add_permastruct(
+			'event',
+			'/events/%eyear%/%event%/',
+			array(
+				'with_front' => false,
+				'ep_mask'    => EP_EVENT,
+				'paged'      => false,
+				'feed'       => false,
+				'endpoints'  => true,
+			)
+		);
+
+				add_rewrite_endpoint( 'speakers', EP_EVENT );
+
+				add_rewrite_rule(
+					'([^/]*)',
+					'index.php?post_type=post&name=$matches[1]',
+					'bottom'
+				);
+}
+add_action( 'init', 'newmr_register_post_types' );
 
 /**
  * Placeholder for plugin activation hook.
  */
 function newmr_plugin_activate() {
-	// TODO: add activation code.
+		newmr_register_post_types();
+		flush_rewrite_rules();
 }
 register_activation_hook( __FILE__, 'newmr_plugin_activate' );
 
@@ -41,6 +209,36 @@ register_activation_hook( __FILE__, 'newmr_plugin_activate' );
  * Placeholder for plugin deactivation hook.
  */
 function newmr_plugin_deactivate() {
-	// TODO: add deactivation code.
+		flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'newmr_plugin_deactivate' );
+
+/**
+ * Replace placeholders in event permalinks.
+ *
+ * @param string  $permalink Permalink.
+ * @param WP_Post $post      Post object.
+ * @param bool    $_leavename Leave post name. Unused.
+ *
+ * @return string
+ */
+function newmr_event_permalink( $permalink, $post, $_leavename ) {
+		unset( $_leavename );
+
+	if ( 'event' !== get_post_type( $post ) ) {
+			return $permalink;
+	}
+
+		$date_from = get_post_meta( $post->ID, 'event_date_from', true );
+	if ( $date_from ) {
+			$year = gmdate( 'Y', strtotime( $date_from ) );
+	} else {
+			$year = get_post_time( 'Y', false, $post, true );
+	}
+
+		$permalink = str_replace( '%eyear%', $year, $permalink );
+		$permalink = str_replace( '%event%', $post->post_name, $permalink );
+
+		return $permalink;
+}
+add_filter( 'post_type_link', 'newmr_event_permalink', 10, 3 );

--- a/tests/phpunit/test-custom-post-type.php
+++ b/tests/phpunit/test-custom-post-type.php
@@ -1,7 +1,39 @@
 <?php
 
 class PostTypeRegistrationTest extends WP_UnitTestCase {
-    public function test_post_type_registered() {
-        $this->assertTrue( post_type_exists( 'newmr_item' ) );
-    }
+	public function set_up() {
+		parent::set_up();
+		newmr_plugin_activate();
+	}
+
+	public function test_post_types_registered() {
+		foreach ( array( 'booth', 'advert', 'event', 'presentation', 'person' ) as $type ) {
+		$this->assertTrue( post_type_exists( $type ), "Post type {$type} not registered" );
+	}
+	}
+
+       public function test_taxonomy_registered() {
+               $this->assertTrue( taxonomy_exists( 'topic' ) );
+       }
+
+       public function test_event_constant_defined() {
+               $this->assertTrue( defined( 'EP_EVENT' ) );
+       }
+
+	public function test_event_permastruct() {
+		global $wp_rewrite;
+		$this->assertSame( '/events/%eyear%/%event%/', $wp_rewrite->extra_permastructs['event']['struct'] );
+	}
+
+       public function test_play_again_rule_exists() {
+               global $wp_rewrite;
+               $rules = $wp_rewrite->extra_rules_top;
+               $this->assertArrayHasKey( '^play-again/([^/]*)/([^/]*)/?$', $rules );
+       }
+
+       public function test_root_post_rule_exists() {
+               global $wp_rewrite;
+               $rules = $wp_rewrite->extra_rules;
+               $this->assertArrayHasKey( '([^/]*)', $rules );
+       }
 }


### PR DESCRIPTION
## Summary
- port post types and `topic` taxonomy from second generation plugin
- add rewrite structures including events permastruct and play-again rules
- flush rewrite rules on activation
- update unit tests for new post types and rewrites
- rename rewrite constant back to `EP_EVENT` and add root post rewrite rule

## Testing
- `composer lint`
- `composer test` *(fails: missing WordPress test environment)*
- `npm test` in `generations/third/newmr-theme`
- `npm run lint` in `generations/third/newmr-theme`


------
https://chatgpt.com/codex/tasks/task_b_687b903c262083299c4c9b5c11b656e3