### PR TITLE
Update docs and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,6 @@ Run `npm install` in `generations/third/newmr-theme` once. Use `npm run build` t
  - Run linters and tests prior to committing:
   - `composer lint`
   - `composer test`
-  - `npm test`
   - `npm run lint`
 - Ensure all checks pass before opening a pull request.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Run the following commands before committing:
 ```bash
 composer test  # Run PHPCS and PHPUnit tests
 npm run lint   # Check code style
-npm test       # Run unit tests
 ```
+
+JavaScript unit tests have not been set up yet.
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="NewMR">
-    <rule ref="WordPress" />
+<rule ref="WordPress" />
+    <arg name="extensions" value="php"/>
     <file>generations/third</file>
     <exclude-pattern>vendor/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- remove the `npm test` requirement from contribution guide
- document that JavaScript unit tests aren't set up
- restrict PHPCS to PHP files

## Testing
- `composer lint`
- `WP_PHPUNIT__DIR=vendor/wp-phpunit/wp-phpunit WP_PHPUNIT__TESTS_CONFIG=$(pwd)/tests/phpunit/wp-config.php WP_DB_HOST=localhost:/var/run/mysqld/mysqld.sock composer test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687b990215548329a93998242142317e