### PR TITLE
Setup WP test environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ This repository hosts multiple generations of the NewMR codebase.
 - **JavaScript/CSS**: format using Prettier. Run `npm run lint` (or `npx prettier --check .`) before committing.
 
 ### Running tests
-Execute `composer test` to run the PHPUnit suite powered by the WordPress test library.
+Run `composer install` once to fetch dependencies. `composer test` will create
+`tests/wordpress` via `tests/bin/install-wp-tests.sh` if it does not exist and
+then execute the PHPUnit suite using that environment.
 
 ### Building the theme
 Run `npm install` in `generations/third/newmr-theme` once. Use `npm run build` to compile assets and `npm run watch` for development.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The repository includes a licensed copy of [Tailwind UI](https://tailwindui.com)
 Run the following commands before committing:
 
 ```bash
-composer test  # Run PHPCS and PHPUnit tests
+composer test  # Sets up tests/wordpress and runs PHPUnit
 npm run lint   # Check code style
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "phpcs -q",
     "phpunit": "phpunit",
-    "test": "phpunit"
+    "test": "bash tests/bin/install-wp-tests.sh && WP_PHPUNIT__DIR=$(pwd)/tests/wordpress/wp-phpunit phpunit"
   },
   "config": {
     "allow-plugins": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,5 +7,6 @@
     </testsuites>
     <php>
         <env name="WP_PHPUNIT__TESTS_CONFIG" value="tests/phpunit/wp-config.php" />
+        <env name="WP_PHPUNIT__DIR" value="tests/wordpress/wp-phpunit" />
     </php>
 </phpunit>

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WP_TESTS_DIR="$ROOT_DIR/tests/wordpress"
+WP_CORE_DIR="$ROOT_DIR/wordpress"
+WP_PHPUNIT_DIR="$ROOT_DIR/vendor/wp-phpunit/wp-phpunit"
+
+if [ -d "$WP_TESTS_DIR" ]; then
+  exit 0
+fi
+
+echo "Setting up WordPress test environment in $WP_TESTS_DIR"
+
+mkdir -p "$WP_TESTS_DIR"
+
+cp -R "$WP_CORE_DIR"/. "$WP_TESTS_DIR"/
+ln -s "$WP_PHPUNIT_DIR" "$WP_TESTS_DIR/wp-phpunit"
+
+echo "WordPress test environment ready."

--- a/tests/phpunit/wp-config.php
+++ b/tests/phpunit/wp-config.php
@@ -18,9 +18,9 @@ define( 'WP_DEBUG', true );
 // WARNING: These tests will DROP ALL TABLES in the database with the prefix named below.
 
 define( 'DB_NAME', getenv( 'WP_DB_NAME' ) ?: 'wp_phpunit_tests' );
-define( 'DB_USER', getenv( 'WP_DB_USER' ) ?: 'root' );
+define( 'DB_USER', getenv( 'WP_DB_USER' ) ?: 'wp' );
 define( 'DB_PASSWORD', getenv( 'WP_DB_PASS' ) ?: '' );
-define( 'DB_HOST', getenv( 'WP_DB_HOST' ) ?: 'localhost' );
+define( 'DB_HOST', getenv( 'WP_DB_HOST' ) ?: '127.0.0.1' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 


### PR DESCRIPTION
## Summary
- add install-wp-tests.sh helper
- auto-create `tests/wordpress` in `composer test`
- point PHPUnit config to the local test library
- document the behaviour in AGENTS and README
- update DB defaults for test user

## Testing
- `composer test`
- `composer lint -v`
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_687b9c268ab883299b585541d579bdad