### PR TITLE
Automate WordPress test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,7 @@ jobs:
           WP_DB_PASS: root
           WP_DB_NAME: wordpress
           WP_PHPUNIT__DIR: vendor/wp-phpunit/wp-phpunit
-        run: |
-          ln -s ../wordpress tests/wordpress
-          composer test
+        run: composer test
 
       - name: Lint JS/CSS
         working-directory: generations/third/newmr-theme
@@ -78,7 +76,8 @@ jobs:
             --admin_user=admin \
             --admin_password=password \
             --admin_email=admin@example.com \
-            --skip-email
+            --skip-email \
+            --path=/var/www/html
 
       - name: Run E2E Tests
         working-directory: generations/third/newmr-theme

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,16 @@ jobs:
             sleep 5
           done
 
+      - name: Install WordPress
+        run: |
+          docker compose run --rm wpcli wp core install \
+            --url=http://localhost:8000 \
+            --title=NewMR \
+            --admin_user=admin \
+            --admin_password=password \
+            --admin_email=admin@example.com \
+            --skip-email
+
       - name: Run E2E Tests
         working-directory: generations/third/newmr-theme
         run: npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+.phpunit.result.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ This repository hosts multiple generations of the NewMR codebase.
 - **JavaScript/CSS**: format using Prettier. Run `npm run lint` (or `npx prettier --check .`) before committing.
 
 ### Running tests
-Run `composer install` once to fetch dependencies. `composer test` will create
-`tests/wordpress` via `tests/bin/install-wp-tests.sh` if it does not exist and
-then execute the PHPUnit suite using that environment.
+Run `composer install` once to fetch dependencies. `composer test` automatically
+sets up a fresh WordPress instance in `tests/wordpress` before running the
+PHPUnit suite.
 
 ### Building the theme
 Run `npm install` in `generations/third/newmr-theme` once. Use `npm run build` to compile assets and `npm run watch` for development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ Start the containers and then execute the tests from the theme directory:
 
 ```bash
 docker compose up -d
+docker compose run --rm wpcli wp core install \
+  --url=http://localhost:8000 \
+  --title=NewMR \
+  --admin_user=admin \
+  --admin_password=password \
+  --admin_email=admin@example.com \
+  --skip-email
 cd generations/third/newmr-theme
 npm run e2e
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "phpcs -q",
     "phpunit": "phpunit",
-    "test": "bash tests/bin/install-wp-tests.sh && WP_PHPUNIT__DIR=$(pwd)/tests/wordpress/wp-phpunit phpunit"
+    "test": "phpunit"
   },
   "config": {
     "allow-plugins": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
     volumes:
+      - wp_data:/var/www/html
       - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
       - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
 
@@ -35,8 +36,10 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
     volumes:
+      - wp_data:/var/www/html
       - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
       - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
 
 volumes:
   db_data:
+  wp_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,18 @@ services:
       - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
       - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
 
+  wpcli:
+    image: wordpress:cli
+    depends_on:
+      - db
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
+      - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
+
 volumes:
   db_data:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,4 +4,5 @@
     <arg name="extensions" value="php"/>
     <file>generations/third</file>
     <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>**/node_modules/*</exclude-pattern>
 </ruleset>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -3,7 +3,24 @@
  * PHPUnit bootstrap file
  */
 
-require_once dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php';
+$root_dir      = dirname( dirname( __DIR__ ) );
+$tests_wp_dir  = $root_dir . '/tests/wordpress';
+$install_script = $root_dir . '/tests/bin/install-wp-tests.sh';
+
+// Always start with a fresh WordPress test environment.
+if ( file_exists( $tests_wp_dir ) ) {
+    exec( 'rm -rf ' . escapeshellarg( $tests_wp_dir ) );
+}
+
+if ( is_readable( $install_script ) ) {
+    passthru( escapeshellcmd( $install_script ), $retval );
+    if ( 0 !== $retval ) {
+        fwrite( STDERR, "Failed installing WordPress test environment\n" );
+        exit( 1 );
+    }
+}
+
+require_once $root_dir . '/vendor/autoload.php';
 
 // Give access to tests_add_filter() function.
 require_once getenv( 'WP_PHPUNIT__DIR' ) . '/includes/functions.php';


### PR DESCRIPTION
## Summary
- rebuild tests/wordpress each test run via bootstrap
- simplify Composer test command
- exclude node_modules from PHPCS scans
- ignore PHPUnit result cache

## Testing
- `composer lint`
- `composer test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687b9e220d208329acb7c1632031f811