### PR TITLE
Add PHPUnit integration tests

### DIFF
--- a/tests/phpunit/test-permalinks.php
+++ b/tests/phpunit/test-permalinks.php
@@ -1,0 +1,30 @@
+<?php
+class EventPermalinkTest extends WP_UnitTestCase {
+    public function set_up() {
+        parent::set_up();
+        newmr_plugin_activate();
+    }
+
+    public function test_event_permalink_uses_meta_year() {
+        $post_id = self::factory()->post->create([
+            'post_type' => 'event',
+            'post_name' => 'my-event',
+            'post_date' => '2015-01-01 00:00:00',
+        ]);
+        update_post_meta( $post_id, 'event_date_from', '2021-03-05' );
+
+        $url = newmr_event_permalink( '/events/%eyear%/%event%/', get_post( $post_id ), false );
+        $this->assertSame( '/events/2021/my-event/', $url );
+    }
+
+    public function test_event_permalink_falls_back_to_post_year() {
+        $post_id = self::factory()->post->create([
+            'post_type' => 'event',
+            'post_name' => 'future-event',
+            'post_date' => '2022-04-01 00:00:00',
+        ]);
+
+        $url = newmr_event_permalink( '/events/%eyear%/%event%/', get_post( $post_id ), false );
+        $this->assertSame( '/events/2022/future-event/', $url );
+    }
+}

--- a/tests/phpunit/test-post-type-supports.php
+++ b/tests/phpunit/test-post-type-supports.php
@@ -1,0 +1,24 @@
+<?php
+class PostTypeSupportsTest extends WP_UnitTestCase {
+    public function set_up() {
+        parent::set_up();
+        newmr_plugin_activate();
+    }
+
+    public function test_booth_supports_features() {
+        $this->assertTrue( post_type_supports( 'booth', 'title' ) );
+        $this->assertTrue( post_type_supports( 'booth', 'editor' ) );
+        $this->assertTrue( post_type_supports( 'booth', 'page-attributes' ) );
+    }
+
+    public function test_event_supports_features() {
+        $this->assertTrue( post_type_supports( 'event', 'thumbnail' ) );
+        $this->assertTrue( post_type_supports( 'event', 'revisions' ) );
+        $this->assertTrue( post_type_supports( 'event', 'shortlinks' ) );
+    }
+
+    public function test_presentation_registered_to_topic() {
+        $taxonomy = get_taxonomy( 'topic' );
+        $this->assertContains( 'presentation', $taxonomy->object_type );
+    }
+}

--- a/tests/phpunit/test-rewrite-endpoint.php
+++ b/tests/phpunit/test-rewrite-endpoint.php
@@ -1,0 +1,22 @@
+<?php
+class RewriteEndpointTest extends WP_UnitTestCase {
+    public function set_up() {
+        parent::set_up();
+        newmr_plugin_activate();
+    }
+
+    public function test_speakers_endpoint_query_var() {
+        $post_id = self::factory()->post->create([
+            'post_type' => 'event',
+            'post_name' => 'session-one',
+            'post_date' => '2020-06-01 00:00:00',
+        ]);
+        update_post_meta( $post_id, 'event_date_from', '2020-06-01' );
+
+        $this->go_to( '/events/2020/session-one/speakers/' );
+        $this->assertTrue( is_single() );
+        global $wp_query;
+        $this->assertSame( 'event', $wp_query->get( 'post_type' ) );
+        $this->assertArrayHasKey( 'speakers', $wp_query->query_vars );
+    }
+}

--- a/tests/phpunit/test-rewrite-endpoint.php
+++ b/tests/phpunit/test-rewrite-endpoint.php
@@ -1,22 +1,15 @@
 <?php
+
 class RewriteEndpointTest extends WP_UnitTestCase {
     public function set_up() {
         parent::set_up();
         newmr_plugin_activate();
     }
 
-    public function test_speakers_endpoint_query_var() {
-        $post_id = self::factory()->post->create([
-            'post_type' => 'event',
-            'post_name' => 'session-one',
-            'post_date' => '2020-06-01 00:00:00',
-        ]);
-        update_post_meta( $post_id, 'event_date_from', '2020-06-01' );
-
-        $this->go_to( '/events/2020/session-one/speakers/' );
-        $this->assertTrue( is_single() );
-        global $wp_query;
-        $this->assertSame( 'event', $wp_query->get( 'post_type' ) );
-        $this->assertArrayHasKey( 'speakers', $wp_query->query_vars );
+    public function test_speakers_endpoint_registered() {
+        global $wp_rewrite;
+        $names = wp_list_pluck( $wp_rewrite->endpoints, 1 );
+        $this->assertContains( 'speakers', $names );
     }
 }
+


### PR DESCRIPTION
## Summary
- expand phpunit coverage for events and endpoints
- check permalink generation logic
- verify registered post type features

## Testing
- `composer lint`
- `npm run lint`
- `composer test` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_b_687ba5ec30948329958fd65bccae52ab