### PR TITLE
Improve e2e tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,7 @@ npm run e2e
 
 Set `BASE_URL` if the site is accessible at a different address.
 
+The end-to-end tests read the `BASE_URL` environment variable to know where
+WordPress is running. If omitted, it defaults to `http://localhost:8000`.
+The test suite waits for this URL to respond before executing any checks.
+

--- a/e2e/homepage.test.js
+++ b/e2e/homepage.test.js
@@ -1,7 +1,38 @@
 import assert from 'node:assert/strict';
-import {test} from 'node:test';
+import {test, before} from 'node:test';
+import {execSync} from 'node:child_process';
+import path from 'node:path';
 
 const baseUrl = process.env.BASE_URL || 'http://localhost:8000';
+
+async function waitForWordPress(url, timeout = 60000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // ignore errors until timeout
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error('WordPress not responding');
+}
+
+before(async () => {
+  await waitForWordPress(baseUrl);
+  try {
+    execSync(
+      'docker compose run --rm wpcli wp plugin activate newmr-plugin',
+      {
+        cwd: path.join(__dirname, '..'),
+        stdio: 'inherit',
+      },
+    );
+  } catch {
+    // Plugin may already be active or docker unavailable
+  }
+});
 
 async function fetchText(url) {
   const res = await fetch(url);
@@ -17,4 +48,9 @@ test('homepage loads', async () => {
 test('navigate to sample page', async () => {
   const text = await fetchText(`${baseUrl}/sample-page/`);
   assert.match(text, /sample page/i);
+});
+
+test('booth archive loads', async () => {
+  const text = await fetchText(`${baseUrl}/exhibition/`);
+  assert.ok(text.length > 0);
 });


### PR DESCRIPTION
## Summary
- wait for Docker WordPress before running tests
- activate the plugin and test a CPT archive
- explain `BASE_URL` in `AGENTS.md`

## Testing
- `composer lint`
- `composer test` *(fails: database connection refused)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687ba5f6f6108329bc8c4fbcaa88dd9d