### PR TITLE
Add block templates from legacy theme

### DIFF
--- a/generations/third/newmr-theme/templates/404.html
+++ b/generations/third/newmr-theme/templates/404.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"tagName":"main","className":"py-8 text-center"} -->
+<main class="py-8 text-center">
+  <!-- wp:heading {"level":1,"className":"text-4xl mb-4"} -->
+  <h1 class="text-4xl mb-4">Not Found</h1>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph {"className":"mb-4"} -->
+  <p>Sorry, but the page you were looking for could not be found.</p>
+  <!-- /wp:paragraph -->
+  <!-- wp:search {"label":"Search","showLabel":false} /-->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/archive-booth.html
+++ b/generations/third/newmr-theme/templates/archive-booth.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/archive-event.html
+++ b/generations/third/newmr-theme/templates/archive-event.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/archive-person.html
+++ b/generations/third/newmr-theme/templates/archive-person.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/comments.html
+++ b/generations/third/newmr-theme/templates/comments.html
@@ -1,0 +1,1 @@
+<!-- wp:comments /-->

--- a/generations/third/newmr-theme/templates/content-presentation.html
+++ b/generations/third/newmr-theme/templates/content-presentation.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/content.html
+++ b/generations/third/newmr-theme/templates/content.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/excerpt-event.html
+++ b/generations/third/newmr-theme/templates/excerpt-event.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-excerpt /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/excerpt-person.html
+++ b/generations/third/newmr-theme/templates/excerpt-person.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-excerpt /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/excerpt-presentation.html
+++ b/generations/third/newmr-theme/templates/excerpt-presentation.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-excerpt /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/excerpt.html
+++ b/generations/third/newmr-theme/templates/excerpt.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-excerpt /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/footer.html
+++ b/generations/third/newmr-theme/templates/footer.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"tagName":"footer","className":"py-4 border-t text-center"} -->
+<footer class="py-4 border-t text-center">
+  <!-- wp:site-title {"level":0,"className":"text-sm"} /-->
+</footer>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/front-page.html
+++ b/generations/third/newmr-theme/templates/front-page.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/header.html
+++ b/generations/third/newmr-theme/templates/header.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"header","className":"py-4 border-b"} -->
+<header class="py-4 border-b">
+  <!-- wp:site-title {"className":"text-3xl"} /-->
+  <!-- wp:navigation /-->
+</header>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/page-events.html
+++ b/generations/third/newmr-theme/templates/page-events.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/page-play-again.html
+++ b/generations/third/newmr-theme/templates/page-play-again.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/page.html
+++ b/generations/third/newmr-theme/templates/page.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
+<article class="prose mx-auto py-8">
+  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/play-again-event.html
+++ b/generations/third/newmr-theme/templates/play-again-event.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/play-again-presentation.html
+++ b/generations/third/newmr-theme/templates/play-again-presentation.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/row-presentation.html
+++ b/generations/third/newmr-theme/templates/row-presentation.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"tagName":"tr"} -->
+<tr>
+  <!-- wp:post-title {"level":0,"isLink":true,"className":"title-col"} /-->
+</tr>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/search.html
+++ b/generations/third/newmr-theme/templates/search.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"main","className":"py-8"} -->
+<main class="py-8">
+  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
+  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
+  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
+  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- /wp:post-template -->
+</main>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/sidebar-event.html
+++ b/generations/third/newmr-theme/templates/sidebar-event.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"aside","className":"p-4 bg-gray-100"} -->
+<aside class="p-4 bg-gray-100">
+  <!-- wp:heading {"level":3} -->
+  <h3>Event Info</h3>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>Additional details about the event.</p>
+  <!-- /wp:paragraph -->
+</aside>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/sidebar-presentation.html
+++ b/generations/third/newmr-theme/templates/sidebar-presentation.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"aside","className":"p-4 bg-gray-100"} -->
+<aside class="p-4 bg-gray-100">
+  <!-- wp:heading {"level":3} -->
+  <h3>Presentation Info</h3>
+  <!-- /wp:heading -->
+  <!-- wp:paragraph -->
+  <p>Details about this presentation.</p>
+  <!-- /wp:paragraph -->
+</aside>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/single-event.html
+++ b/generations/third/newmr-theme/templates/single-event.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
+<article class="prose mx-auto py-8">
+  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/single-person.html
+++ b/generations/third/newmr-theme/templates/single-person.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
+<article class="prose mx-auto py-8">
+  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/single-presentation.html
+++ b/generations/third/newmr-theme/templates/single-presentation.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
+<article class="prose mx-auto py-8">
+  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
+  <!-- wp:post-content /-->
+</article>
+<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/slim-presentation.html
+++ b/generations/third/newmr-theme/templates/slim-presentation.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"tagName":"article","className":"prose"} -->
+<article class="prose">
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:video {"className":"my-4"} /-->
+</article>
+<!-- /wp:group -->


### PR DESCRIPTION
## Summary
- scaffold new block templates in `newmr-theme` to match legacy PHP templates

## Testing
- `npm run lint`
- `composer lint`
- `composer test` *(fails: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_b_687bad685d2883299991a4a59754b94f