### PR TITLE
Add test Dockerfile

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+FROM php:8.1-cli
+
+RUN apt-get update \
+    && apt-get install -y git unzip \
+    && docker-php-ext-install mysqli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app


### PR DESCRIPTION
## Summary
- add `Dockerfile.test` using `php:8.1-cli` for test runs

## Testing
- `composer lint`
- `composer test` *(fails: connection refused)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687c9e27a00883299e48f3fec6b3e169