### PR TITLE
Add tests service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,20 @@ services:
       - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
       - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
 
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    environment:
+      WP_DB_HOST: db
+      WP_DB_USER: wordpress
+      WP_DB_PASS: wordpress
+      WP_DB_NAME: wordpress
+    volumes:
+      - ./:/app
+    depends_on:
+      - db
+
 volumes:
   db_data:
   wp_data:


### PR DESCRIPTION
## Summary
- enable a dedicated `tests` container in `docker-compose.yml`

## Testing
- `composer lint`
- `composer test` *(fails: Error establishing a database connection)*
- `npm run lint` in `generations/third/newmr-theme`


------
https://chatgpt.com/codex/tasks/task_b_687c9fc183a88329b584d56662959bb7