### PR TITLE
Use Docker for running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ This repository hosts multiple generations of the NewMR codebase.
 - **JavaScript/CSS**: format using Prettier. Run `npm run lint` (or `npx prettier --check .`) before committing.
 
 ### Running tests
-Run `composer install` once to fetch dependencies. `composer test` automatically
+Run `composer install` once to fetch dependencies. `docker compose run --rm tests composer test` automatically
 sets up a fresh WordPress instance in `tests/wordpress` before running the
-PHPUnit suite.
+PHPUnit suite. This ensures consistent PHP and MySQL versions.
 
 ### Building the theme
 Run `npm install` in `generations/third/newmr-theme` once. Use `npm run build` to compile assets and `npm run watch` for development.
@@ -23,7 +23,7 @@ Run `npm install` in `generations/third/newmr-theme` once. Use `npm run build` t
 - Keep commits focused: one logical change per commit.
  - Run linters and tests prior to committing:
   - `composer lint`
-  - `composer test`
+  - `docker compose run --rm tests composer test`
   - `npm run lint`
 - Ensure all checks pass before opening a pull request.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ composer install
 npm install --prefix generations/third/newmr-theme
 
 # Run the test suite
-composer test
+docker compose run --rm tests composer test
+# Running the tests via Docker ensures consistent PHP and MySQL versions
 
 # Build the theme assets
 npm run --prefix generations/third/newmr-theme build
@@ -48,7 +49,8 @@ The repository includes a licensed copy of [Tailwind UI](https://tailwindui.com)
 Run the following commands before committing:
 
 ```bash
-composer test  # Sets up tests/wordpress and runs PHPUnit
+docker compose run --rm tests composer test  # Sets up tests/wordpress and runs PHPUnit
+# Running the tests via Docker ensures consistent PHP and MySQL versions
 npm run lint   # Check code style
 ```
 

--- a/generations/third/README.md
+++ b/generations/third/README.md
@@ -14,7 +14,8 @@ Use the root `docker-compose.yml` file to spin up a development site:
 docker compose up -d
 composer install
 npm install --prefix newmr-theme
-composer test
+docker compose run --rm tests composer test
+# Running the tests via Docker ensures consistent PHP and MySQL versions
 npm run --prefix newmr-theme build
 ```
 


### PR DESCRIPTION
## Summary
- update docs and contributor guide to use `docker compose run --rm tests composer test`
- note that using Docker ensures consistent PHP and MySQL versions

## Testing
- `composer lint`
- `docker compose run --rm tests composer test` *(fails: Cannot connect to Docker daemon)*
- `npm install --prefix generations/third/newmr-theme`
- `npm run --prefix generations/third/newmr-theme lint`

------
https://chatgpt.com/codex/tasks/task_b_687ca21ddcc883298f6cef589a67dcdc