### PR TITLE
Update CI to run tests container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,21 @@ jobs:
       - name: Lint PHP
         run: composer lint
 
+      - name: Start db
+        run: docker compose up -d db
+
+      - name: Wait for db
+        run: |
+          for i in {1..30}; do
+            if docker compose exec db mysqladmin ping -hlocalhost -uwordpress -pwordpress --silent; then
+              echo "Database is up"
+              break
+            fi
+            sleep 5
+          done
+
       - name: Run PHPUnit
-        env:
-          WP_DB_HOST: 127.0.0.1
-          WP_DB_USER: root
-          WP_DB_PASS: root
-          WP_DB_NAME: wordpress
-          WP_PHPUNIT__DIR: vendor/wp-phpunit/wp-phpunit
-        run: composer test
+        run: docker compose run --rm tests composer test
 
       - name: Lint JS/CSS
         working-directory: generations/third/newmr-theme


### PR DESCRIPTION
## Summary
- run PHPUnit through docker compose to ensure consistent environment
- start and wait for the database container before running tests

## Testing
- `composer lint`
- `npm run lint`
- ❌ `composer test` *(failed: Error establishing a database connection)*

------
https://chatgpt.com/codex/tasks/task_b_687ca283353c832982ce4129925b63ac