### PR TITLE
Add production data sync helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ docker compose run --rm tests composer test
 
 # Build the theme assets
 npm run --prefix generations/third/newmr-theme build
+
+# (Optional) Import production content and uploads
+scripts/pull-production-data.sh
 ```
+
+The `pull-production-data.sh` helper expects environment variables such as
+`PROD_HOST`, `PROD_DB_NAME`, and `PROD_WP_PATH`. It uses SSH to dump the
+production database and sync the `wp-content/uploads` directory.
 
 ## Building the Theme
 Run `npm install` inside `generations/third/newmr-theme` and then `npm run build` to compile the Tailwind styles with Vite. Use `npm run watch` during development. The compiled CSS in `dist/style.css` is excluded from version control.

--- a/scripts/pull-production-data.sh
+++ b/scripts/pull-production-data.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Environment variables:
+#   PROD_HOST        - Hostname of production server (required)
+#   PROD_SSH_USER    - SSH user for production (defaults to current user)
+#   PROD_DB_NAME     - Production database name (required)
+#   PROD_WP_PATH     - Path to WordPress root on production (required)
+#   PROD_PLUGINS     - Space separated plugin directories to copy (optional)
+
+: "${PROD_HOST:?PROD_HOST is required}"
+PROD_SSH_USER="${PROD_SSH_USER:-$USER}"
+: "${PROD_DB_NAME:?PROD_DB_NAME is required}"
+: "${PROD_WP_PATH:?PROD_WP_PATH is required}"
+PROD_PLUGINS="${PROD_PLUGINS:-}"
+
+REMOTE="${PROD_SSH_USER}@${PROD_HOST}"
+
+# Import database
+echo "Exporting database from ${REMOTE}..."
+ssh "$REMOTE" "mysqldump ${PROD_DB_NAME}" | docker compose exec -T db mysql ${PROD_DB_NAME}
+
+echo "Syncing uploads directory..."
+mkdir -p wordpress/wp-content/uploads
+rsync -avz --delete "${REMOTE}:${PROD_WP_PATH}/wp-content/uploads/" "wordpress/wp-content/uploads/"
+
+for plugin in $PROD_PLUGINS; do
+    echo "Syncing plugin $plugin..."
+    mkdir -p "wordpress/wp-content/plugins/${plugin}"
+    rsync -avz --delete "${REMOTE}:${PROD_WP_PATH}/wp-content/plugins/${plugin}/" "wordpress/wp-content/plugins/${plugin}/"
+done
+
+echo "Production data pull complete."


### PR DESCRIPTION
## Summary
- add scripts directory with production data pull script
- document script usage in README

## Testing
- `composer lint`
- `docker compose run --rm tests composer test` *(fails: command not found)*
- `npm run --prefix generations/third/newmr-theme lint`

------
https://chatgpt.com/codex/tasks/task_b_687cab2b909883298654458efd081959