### PR TITLE
Add theme options and analytics

### DIFF
--- a/generations/third/newmr-plugin/includes/class-newmr-settings.php
+++ b/generations/third/newmr-plugin/includes/class-newmr-settings.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Admin settings for NewMR.
+ *
+ * @package NewMR
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+if ( ! class_exists( 'NewMR_Settings' ) ) {
+	/**
+	 * Admin page for managing NewMR settings.
+	 */
+	class NewMR_Settings {
+		/**
+		 * Setup hooks.
+		 */
+		public function __construct() {
+			add_action( 'admin_menu', array( $this, 'register_page' ) );
+		}
+
+		/**
+		 * Register settings page under "Settings".
+		 */
+		public function register_page() {
+			add_options_page(
+				__( 'NewMR Settings', 'newmr' ),
+				__( 'NewMR Settings', 'newmr' ),
+				'manage_options',
+				'newmr-settings',
+				array( $this, 'render_page' )
+			);
+		}
+
+		/**
+		 * Render the settings page.
+		 */
+		public function render_page() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html__( 'You do not have permission to access this page.', 'newmr' ) );
+			}
+
+			if ( isset( $_POST['newmr_settings_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['newmr_settings_nonce'] ) ), 'newmr_save_settings' ) ) {
+				if ( isset( $_POST['front_middle_left'] ) ) {
+					update_option( 'newmr_front_middle_left', wp_kses_post( wp_unslash( $_POST['front_middle_left'] ) ) );
+				}
+				if ( isset( $_POST['front_bottom_right'] ) ) {
+					update_option( 'newmr_front_bottom_right', wp_kses_post( wp_unslash( $_POST['front_bottom_right'] ) ) );
+				}
+				if ( isset( $_POST['ga_tracking_code'] ) ) {
+					update_option( 'newmr_ga_tracking_code', sanitize_text_field( wp_unslash( $_POST['ga_tracking_code'] ) ) );
+				}
+				if ( isset( $_POST['left_footer_link'] ) ) {
+					update_option( 'newmr_left_footer_link', sanitize_text_field( wp_unslash( $_POST['left_footer_link'] ) ) );
+				}
+				if ( isset( $_POST['right_footer_link'] ) ) {
+					update_option( 'newmr_right_footer_link', sanitize_text_field( wp_unslash( $_POST['right_footer_link'] ) ) );
+				}
+				if ( isset( $_POST['featured_video'] ) ) {
+					update_option( 'newmr_featured_video', sanitize_text_field( wp_unslash( $_POST['featured_video'] ) ) );
+				}
+				echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'newmr' ) . '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+
+			$front_middle_left  = get_option( 'newmr_front_middle_left', '' );
+			$front_bottom_right = get_option( 'newmr_front_bottom_right', '' );
+			$ga_tracking_code   = get_option( 'newmr_ga_tracking_code', '' );
+			$left_footer_link   = get_option( 'newmr_left_footer_link', '' );
+			$right_footer_link  = get_option( 'newmr_right_footer_link', '' );
+			$featured_video     = get_option( 'newmr_featured_video', '' );
+			?>
+			<div class="wrap">
+				<h1><?php esc_html_e( 'NewMR Settings', 'newmr' ); ?></h1>
+				<form method="post" action="">
+					<?php wp_nonce_field( 'newmr_save_settings', 'newmr_settings_nonce' ); ?>
+					<p>
+						<label for="front_middle_left"><strong><?php esc_html_e( 'Front Middle Left (Donate Box):', 'newmr' ); ?></strong></label><br />
+						<textarea name="front_middle_left" id="front_middle_left" style="width:90%;height:100px;" ><?php echo esc_textarea( $front_middle_left ); ?></textarea>
+					</p>
+					<p>
+						<label for="front_bottom_right"><strong><?php esc_html_e( 'Front Bottom Right (About NewMR Box):', 'newmr' ); ?></strong></label><br />
+						<textarea name="front_bottom_right" id="front_bottom_right" style="width:90%;height:200px;" ><?php echo esc_textarea( $front_bottom_right ); ?></textarea>
+					</p>
+					<p>
+						<label for="ga_tracking_code"><strong><?php esc_html_e( 'Google Analytics Tracking:', 'newmr' ); ?></strong></label>
+						<input name="ga_tracking_code" id="ga_tracking_code" type="text" value="<?php echo esc_attr( $ga_tracking_code ); ?>" class="regular-text" />
+					</p>
+					<p>
+						<label for="left_footer_link"><strong><?php esc_html_e( 'Left Footer Link:', 'newmr' ); ?></strong></label>
+						<select name="left_footer_link" id="left_footer_link">
+							<option value=""><?php esc_html_e( '--Select a Page--', 'newmr' ); ?></option>
+							<?php
+							$query = new WP_Query(
+								array(
+									'post_type' => 'page',
+									'nopaging'  => true,
+								)
+							);
+							while ( $query->have_posts() ) {
+								$query->the_post();
+								$pagename = get_post()->post_name;
+								echo '<option value="' . esc_attr( $pagename ) . '" ' . selected( $pagename, $left_footer_link, false ) . '>' . esc_html( get_the_title() ) . '</option>';
+							}
+							wp_reset_postdata();
+							?>
+						</select>
+					</p>
+					<p>
+						<label for="right_footer_link"><strong><?php esc_html_e( 'Right Footer Link:', 'newmr' ); ?></strong></label>
+						<select name="right_footer_link" id="right_footer_link">
+							<option value=""><?php esc_html_e( '--Select a Page--', 'newmr' ); ?></option>
+							<?php
+							$query = new WP_Query(
+								array(
+									'post_type' => 'page',
+									'nopaging'  => true,
+								)
+							);
+							while ( $query->have_posts() ) {
+								$query->the_post();
+								$pagename = get_post()->post_name;
+								echo '<option value="' . esc_attr( $pagename ) . '" ' . selected( $pagename, $right_footer_link, false ) . '>' . esc_html( get_the_title() ) . '</option>';
+							}
+							wp_reset_postdata();
+							?>
+						</select>
+					</p>
+					<p>
+						<label for="featured_video"><strong><?php esc_html_e( 'Featured Video:', 'newmr' ); ?></strong></label>
+						<select name="featured_video" id="featured_video" style="width:83%;">
+							<option value=""><?php esc_html_e( '--Select a Presentation--', 'newmr' ); ?></option>
+							<?php
+							$query = new WP_Query(
+								array(
+									'post_type' => 'presentation',
+									'nopaging'  => true,
+									'orderby'   => 'date',
+									'order'     => 'DESC',
+								)
+							);
+							while ( $query->have_posts() ) {
+								$query->the_post();
+								$name = get_post()->post_name;
+								echo '<option value="' . esc_attr( $name ) . '" ' . selected( $name, $featured_video, false ) . '>' . esc_html( get_the_title() ) . '</option>';
+							}
+							wp_reset_postdata();
+							?>
+						</select>
+					</p>
+					<p>
+						<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save Settings', 'newmr' ); ?>" />
+					</p>
+				</form>
+			</div>
+			<?php
+		}
+	}
+}

--- a/generations/third/newmr-plugin/includes/googleanalytics.php
+++ b/generations/third/newmr-plugin/includes/googleanalytics.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Google Analytics tracking snippet.
+ *
+ * @package NewMR
+ */
+
+?>
+<script>
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	ga('create', '<?php echo esc_js( get_option( 'newmr_ga_tracking_code' ) ); ?>', 'newmr.org');
+	ga('send', 'pageview');
+</script>

--- a/generations/third/newmr-plugin/newmr-plugin.php
+++ b/generations/third/newmr-plugin/newmr-plugin.php
@@ -200,8 +200,14 @@ add_action( 'init', 'newmr_register_post_types' );
  * Placeholder for plugin activation hook.
  */
 function newmr_plugin_activate() {
-		newmr_register_post_types();
-		flush_rewrite_rules();
+				newmr_register_post_types();
+				add_option( 'newmr_front_middle_left', '' );
+				add_option( 'newmr_front_bottom_right', '' );
+				add_option( 'newmr_ga_tracking_code', '' );
+				add_option( 'newmr_left_footer_link', '' );
+				add_option( 'newmr_right_footer_link', '' );
+				add_option( 'newmr_featured_video', '' );
+				flush_rewrite_rules();
 }
 register_activation_hook( __FILE__, 'newmr_plugin_activate' );
 
@@ -248,6 +254,7 @@ add_filter( 'post_type_link', 'newmr_event_permalink', 10, 3 );
  */
 require_once __DIR__ . '/includes/class-newmr-dashboard-glancer.php';
 require_once __DIR__ . '/includes/class-newmr-adverts-widget.php';
+require_once __DIR__ . '/includes/class-newmr-settings.php';
 
 
 // Register dashboard glancer items for custom post types.
@@ -258,6 +265,19 @@ $glancer->add( array( 'advert', 'booth', 'event', 'presentation', 'person' ) );
 add_action(
 	'widgets_init',
 	static function () {
-				register_widget( 'NewMR_Adverts_Widget' );
+								register_widget( 'NewMR_Adverts_Widget' );
 	}
 );
+
+/**
+ * Output Google Analytics script if tracking code is set.
+ */
+function newmr_output_ga() {
+	if ( get_option( 'newmr_ga_tracking_code' ) ) {
+			require __DIR__ . '/includes/googleanalytics.php';
+	}
+}
+add_action( 'wp_head', 'newmr_output_ga' );
+
+// Initialize settings page.
+$newmr_settings = new NewMR_Settings();

--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -12,3 +12,58 @@ function newmr_theme_setup() {
 	add_theme_support( 'wp-block-styles' );
 }
 add_action( 'after_setup_theme', 'newmr_theme_setup' );
+
+/**
+ * Output the donate box content.
+ */
+function donate_box() {
+		echo apply_filters( 'the_content', stripslashes( get_option( 'newmr_front_middle_left' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+/**
+ * Output the About NewMR box content.
+ */
+function about_newmr_box() {
+		echo apply_filters( 'the_content', stripslashes( get_option( 'newmr_front_bottom_right' ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+/**
+ * Display link selected for the left footer.
+ */
+function left_footer_link() {
+		$name = get_option( 'newmr_left_footer_link' );
+	if ( '' === $name ) {
+			return;
+	}
+		$query = new WP_Query( 'pagename=' . $name );
+	if ( $query->have_posts() ) {
+			$query->the_post();
+			echo '<a href="' . esc_url( get_permalink() ) . '" class="left-link">' . esc_html( get_the_title() ) . '</a>';
+			wp_reset_postdata();
+	}
+}
+
+/**
+ * Display link selected for the right footer.
+ */
+function right_footer_link() {
+		$name = get_option( 'newmr_right_footer_link' );
+	if ( '' === $name ) {
+			return;
+	}
+		$query = new WP_Query( 'pagename=' . $name );
+	if ( $query->have_posts() ) {
+			$query->the_post();
+			echo '<a href="' . esc_url( get_permalink() ) . '" class="right-link">' . esc_html( get_the_title() ) . '</a>';
+			wp_reset_postdata();
+	}
+}
+
+/**
+ * Return the slug of the selected featured video.
+ *
+ * @return string
+ */
+function featured_video_slug() {
+		return get_option( 'newmr_featured_video', '' );
+}


### PR DESCRIPTION
## Summary
- add settings admin page in plugin with options for GA code and theme boxes
- output Google Analytics script in `wp_head`
- expose helper functions from theme for donate/about boxes and footer links

## Testing
- `composer lint`
- `composer test` *(fails: database connection)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687dc19d81f48329b79ac862bd40f31a