### PR TITLE
Add legacy query behavior

### DIFF
--- a/tests/phpunit/test-query-modifications.php
+++ b/tests/phpunit/test-query-modifications.php
@@ -1,0 +1,26 @@
+<?php
+class QueryModificationTest extends WP_UnitTestCase {
+    public function set_up() {
+        parent::set_up();
+        newmr_plugin_activate();
+    }
+
+    public function test_booth_query_sorted_and_unlimited() {
+        $q = new WP_Query( array( 'post_type' => 'booth' ) );
+        $this->assertSame( 'ASC', $q->get( 'order' ) );
+        $this->assertSame( -1, $q->get( 'posts_per_page' ) );
+    }
+
+    public function test_person_query_normalization_and_sort() {
+        $q = new WP_Query( array( 'post_type' => 'person', 'name' => 'John Doe' ) );
+        $this->assertSame( 'john-doe', $q->get( 'name' ) );
+        $this->assertSame( -1, $q->get( 'posts_per_page' ) );
+        $this->assertSame( 'title', $q->get( 'orderby' ) );
+        $this->assertSame( 'ASC', $q->get( 'order' ) );
+    }
+
+    public function test_advert_query_sorted() {
+        $q = new WP_Query( array( 'post_type' => 'advert' ) );
+        $this->assertSame( 'ASC', $q->get( 'order' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- replicate old sort and paging logic via `pre_get_posts`
- normalize `person` slugs and disable sharing on custom types
- add PHPUnit tests for query modifications

## Testing
- `composer lint`
- `npm run lint` in `generations/third/newmr-theme`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_687dc7a300a48329a7485171ff4ff86b