### PR TITLE
Add Jetpack mobile compatibility helpers

### DIFF
--- a/generations/third/README.md
+++ b/generations/third/README.md
@@ -28,4 +28,15 @@ The rewrite is still missing several features from the second-generation code:
 - Adverts widgets.
 - Theme options page and Google Analytics snippet.
 - Custom post sorting and share integration.
-- Jetpack/mobile theme compatibility.
+
+## Mobile Theme Compatibility
+
+The plugin ships with helpers that mimic `jetpack_check_mobile()` and disable
+Jetpack\'s legacy mobile theme. When the Jetpack plugin reports a mobile device
+the filter `template_include` will look for `mobile.php` in the active theme and
+use it if present.
+
+1. Install and activate the Jetpack plugin.
+2. (Optional) Create a `mobile.php` template inside `newmr-theme` to provide a
+   simplified layout for mobile devices. If the file is missing the normal theme
+   templates are used.

--- a/generations/third/newmr-plugin/includes/jetpack-mobile.php
+++ b/generations/third/newmr-plugin/includes/jetpack-mobile.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Jetpack mobile compatibility helpers.
+ *
+ * Provides a minimal replacement for the old `jetpack_check_mobile` function and
+ * hooks to disable Jetpack's legacy mobile theme. Optionally swaps in a mobile
+ * template from the active theme when Jetpack reports a mobile device.
+ *
+ * @package NewMR
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Determine if Jetpack thinks the current request is from a mobile device.
+ *
+ * Mirrors the behaviour of `jetpack_check_mobile()` from the Jetpack plugin.
+ *
+ * @return bool
+ */
+function newmr_jetpack_check_mobile() {
+	if ( ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) || ( defined( 'APP_REQUEST' ) && APP_REQUEST ) ) {
+		return false;
+	}
+
+	if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) || ( isset( $_COOKIE['akm_mobile'] ) && 'false' === $_COOKIE['akm_mobile'] ) ) {
+		return false;
+	}
+
+	if ( newmr_jetpack_mobile_exclude() ) {
+		return false;
+	}
+
+	if ( 1 === (int) get_option( 'wp_mobile_disable' ) ) {
+		return false;
+	}
+
+	if ( isset( $_COOKIE['akm_mobile'] ) && 'true' === $_COOKIE['akm_mobile'] ) {
+		return true;
+	}
+
+	$is_mobile = false;
+	if ( function_exists( 'jetpack_is_mobile' ) ) {
+		$is_mobile = jetpack_is_mobile();
+	}
+
+	return (bool) apply_filters( 'jetpack_check_mobile', $is_mobile );
+}
+
+/**
+ * Whether the current request should be excluded from mobile mode.
+ *
+ * @return bool
+ */
+function newmr_jetpack_mobile_exclude() {
+	$exclude          = false;
+	$pages_to_exclude = array(
+		'wp-admin',
+		'wp-comments-post.php',
+		'wp-mail.php',
+		'wp-login.php',
+		'wp-activate.php',
+	);
+
+	foreach ( $pages_to_exclude as $page ) {
+		if ( isset( $_SERVER['REQUEST_URI'] ) && str_contains( strtolower( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), $page ) ) {
+			$exclude = true;
+			break;
+		}
+	}
+
+	if ( defined( 'DOING_AJAX' ) && true === DOING_AJAX ) {
+		$exclude = false;
+	}
+
+	if ( isset( $GLOBALS['wp_customize'] ) ) {
+		return true;
+	}
+
+	return (bool) apply_filters( 'jetpack_mobile_exclude', $exclude );
+}
+
+/**
+ * Load a mobile template when available.
+ *
+ * @param string $template Current template path.
+ * @return string
+ */
+function newmr_maybe_load_mobile_template( $template ) {
+	if ( ! newmr_jetpack_check_mobile() ) {
+		return $template;
+	}
+
+	$mobile_template = get_stylesheet_directory() . '/mobile.php';
+	if ( file_exists( $mobile_template ) ) {
+		return $mobile_template;
+	}
+
+	return $template;
+}
+
+/**
+ * Setup Jetpack mobile integration.
+ */
+function newmr_setup_jetpack_mobile() {
+	// Disable Jetpack's legacy mobile theme if the plugin is present.
+	add_filter( 'jetpack_has_mobile_theme', '__return_false' );
+
+	// Swap template when a mobile.php file exists in the active theme.
+	add_filter( 'template_include', 'newmr_maybe_load_mobile_template' );
+}
+add_action( 'plugins_loaded', 'newmr_setup_jetpack_mobile' );

--- a/generations/third/newmr-plugin/newmr-plugin.php
+++ b/generations/third/newmr-plugin/newmr-plugin.php
@@ -255,6 +255,7 @@ add_filter( 'post_type_link', 'newmr_event_permalink', 10, 3 );
 require_once __DIR__ . '/includes/class-newmr-dashboard-glancer.php';
 require_once __DIR__ . '/includes/class-newmr-adverts-widget.php';
 require_once __DIR__ . '/includes/class-newmr-settings.php';
+require_once __DIR__ . '/includes/jetpack-mobile.php';
 
 
 // Register dashboard glancer items for custom post types.

--- a/tests/phpunit/test-jetpack-mobile.php
+++ b/tests/phpunit/test-jetpack-mobile.php
@@ -9,6 +9,9 @@ class JetpackMobileTest extends WP_UnitTestCase {
         parent::set_up();
         newmr_plugin_activate();
 
+        // Provide a user agent so mobile checks don't fail early.
+        $_SERVER['HTTP_USER_AGENT'] = 'WordPress PHPUnit';
+
         // Ensure jetpack_is_mobile() can be mocked.
         if ( ! function_exists( 'jetpack_is_mobile' ) ) {
             function jetpack_is_mobile() {
@@ -27,6 +30,7 @@ class JetpackMobileTest extends WP_UnitTestCase {
         if ( file_exists( $this->mobile_template ) ) {
             unlink( $this->mobile_template );
         }
+        unset( $_SERVER['HTTP_USER_AGENT'] );
         parent::tear_down();
     }
 

--- a/tests/phpunit/test-jetpack-mobile.php
+++ b/tests/phpunit/test-jetpack-mobile.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for Jetpack mobile compatibility.
+ */
+class JetpackMobileTest extends WP_UnitTestCase {
+    private $mobile_template;
+
+    public function set_up() {
+        parent::set_up();
+        newmr_plugin_activate();
+
+        // Ensure jetpack_is_mobile() can be mocked.
+        if ( ! function_exists( 'jetpack_is_mobile' ) ) {
+            function jetpack_is_mobile() {
+                return isset( $GLOBALS['__test_is_mobile'] ) ? $GLOBALS['__test_is_mobile'] : false;
+            }
+        }
+
+        // Create a dummy mobile template inside the active theme.
+        $this->mobile_template = get_stylesheet_directory() . '/mobile.php';
+        if ( ! file_exists( $this->mobile_template ) ) {
+            file_put_contents( $this->mobile_template, '<?php // mobile template ?>' );
+        }
+    }
+
+    public function tear_down() {
+        if ( file_exists( $this->mobile_template ) ) {
+            unlink( $this->mobile_template );
+        }
+        parent::tear_down();
+    }
+
+    public function test_check_mobile_false_by_default() {
+        $GLOBALS['__test_is_mobile'] = false;
+        $this->assertFalse( newmr_jetpack_check_mobile() );
+    }
+
+    public function test_check_mobile_true_when_reported() {
+        $GLOBALS['__test_is_mobile'] = true;
+        $this->assertTrue( newmr_jetpack_check_mobile() );
+    }
+
+    public function test_template_swaps_when_mobile() {
+        $GLOBALS['__test_is_mobile'] = true;
+        $filtered = newmr_maybe_load_mobile_template( '/path/to/index.php' );
+        $this->assertSame( $this->mobile_template, $filtered );
+    }
+
+    public function test_jetpack_theme_disabled_filter() {
+        $this->assertFalse( apply_filters( 'jetpack_has_mobile_theme', true ) );
+    }
+}


### PR DESCRIPTION
## Summary
- add jetpack mobile detection helper
- disable Jetpack legacy theme and optionally load `mobile.php`
- document Jetpack usage
- add integration test for mobile helper

## Testing
- `composer lint`
- `composer test` *(fails: Connection refused)*
- `npm run lint --prefix generations/third/newmr-theme` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687dcb322df08329beec03ae71572caa