### PR TITLE
Add header search

### DIFF
--- a/generations/third/newmr-theme/templates/header.html
+++ b/generations/third/newmr-theme/templates/header.html
@@ -5,7 +5,12 @@
     class="mx-auto max-w-7xl flex items-center justify-between gap-x-8 px-4 py-4 sm:px-6 lg:px-8"
   >
     <!-- wp:site-logo /-->
-    <!-- wp:navigation {"overlayMenu":"modal"} /-->
+    <!-- wp:group {"className":"flex items-center gap-x-4"} -->
+    <div class="flex items-center gap-x-4">
+      <!-- wp:navigation {"overlayMenu":"modal"} /-->
+      <!-- wp:search {"label":"Search","showLabel":false,"className":"hidden sm:block"} /-->
+    </div>
+    <!-- /wp:group -->
   </div>
   <!-- /wp:group -->
 </header>


### PR DESCRIPTION
## Summary
- add WordPress search block beside navigation for easy access
- hide search on mobile via Tailwind classes

## Testing
- `composer lint`
- `npm run lint`
- `docker compose run --rm tests composer test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880673a05608329b7a5ea74551f1ba8