### PR TITLE
Add dynamic presentation row partial

### DIFF
--- a/generations/third/newmr-theme/templates/row-presentation.html
+++ b/generations/third/newmr-theme/templates/row-presentation.html
@@ -1,5 +1,0 @@
-<!-- wp:group {"tagName":"tr"} -->
-<tr>
-  <!-- wp:post-title {"level":0,"isLink":true,"className":"title-col"} /-->
-</tr>
-<!-- /wp:group -->

--- a/generations/third/newmr-theme/templates/row-presentation.php
+++ b/generations/third/newmr-theme/templates/row-presentation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Presentation row partial.
+ *
+ * Displays speakers, title, watch link and slide download link.
+ *
+ * @package NewMR
+ */
+
+$connected = new WP_Query(
+	array(
+		'connected_type'  => 'presentation_to_person',
+		'connected_items' => get_post(),
+		'nopaging'        => true,
+	)
+);
+$persons   = array();
+while ( $connected->have_posts() ) {
+	$connected->the_post();
+	$persons[] = '<a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
+}
+wp_reset_postdata();
+$people = implode( ', ', $persons );
+$slides = get_post_meta( get_the_ID(), 'presentation_slides', true );
+?>
+<tr>
+<td class="speaker-col p-2"><?php echo wp_kses_post( $people ); ?></td>
+<td class="title-col p-2"><a href="<?php the_permalink(); ?>" class="hover:underline"><?php the_title(); ?></a></td>
+<td class="watch-col p-2"><a href="<?php the_permalink(); ?>" class="text-blue-600 hover:underline">Watch</a></td>
+<td class="download-col p-2">
+<?php if ( $slides ) : ?>
+<a href="<?php echo esc_url( $slides ); ?>" class="text-blue-600 hover:underline">Download</a>
+<?php endif; ?>
+</td>
+</tr>


### PR DESCRIPTION
## Summary
- replace `row-presentation.html` with PHP version
- display speakers, title, watch link and slides link using Tailwind table classes

## Testing
- `composer lint`
- `composer test` *(fails: Error establishing a database connection)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68807b31d66c8329b0e22f3cdd5023ae