### PR TITLE
Implement Play Again presentation template

### DIFF
--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -75,3 +75,38 @@ add_shortcode( 'donate_box', 'donate_box' );
 add_shortcode( 'about_newmr_box', 'about_newmr_box' );
 add_shortcode( 'left_footer_link', 'left_footer_link' );
 add_shortcode( 'right_footer_link', 'right_footer_link' );
+/**
+ * Return formatted event date range based on meta fields.
+ *
+ * @return string Event dates HTML
+ */
+function newmr_event_dates() {
+		$from = get_post_meta( get_the_ID(), 'event_date_from', true );
+		$to   = get_post_meta( get_the_ID(), 'event_date_to', true );
+	if ( strlen( $from ) < 1 ) {
+			return '';
+	}
+	if ( $from === $to ) {
+			$dates = date_i18n( 'jS F', $from );
+	} elseif ( gmdate( 'F', $from ) === gmdate( 'F', $to ) ) {
+			$dates = date_i18n( 'jS', $from ) . ' - ' . date_i18n( 'jS F', $to );
+	} else {
+			$dates = date_i18n( 'jS F', $from ) . ' - ' . date_i18n( 'jS F', $to );
+	}
+		return '<span class="event-dates">' . esc_html( $dates ) . '</span>';
+}
+add_shortcode( 'event_dates', 'newmr_event_dates' );
+
+/**
+ * Output a "Free" badge when the event_free meta equals "yes".
+ *
+ * @return string
+ */
+function newmr_free_badge() {
+		$is_free = get_post_meta( get_the_ID(), 'event_free', true );
+	if ( 'yes' === $is_free ) {
+			return '<span class="free-badge text-green-600">' . esc_html__( 'Free', 'newmr' ) . '</span>';
+	}
+		return '';
+}
+add_shortcode( 'free_badge', 'newmr_free_badge' );

--- a/generations/third/newmr-theme/templates/play-again-presentation.html
+++ b/generations/third/newmr-theme/templates/play-again-presentation.html
@@ -1,10 +1,19 @@
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
-  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
-  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
-  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
-  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- wp:post-template {"className":"grid gap-6 max-w-4xl mx-auto"} -->
+  <!-- wp:group {"tagName":"article","className":"relative flex bg-white shadow rounded-lg overflow-hidden"} -->
+  <article class="relative flex bg-white shadow rounded-lg overflow-hidden">
+    <!-- wp:post-featured-image {"className":"h-32 w-32 object-cover border-r-2 border-blue-500"} /-->
+    <!-- wp:group {"className":"p-4 flex flex-col justify-center gap-1"} -->
+    <div class="p-4 flex flex-col justify-center gap-1">
+      <!-- wp:post-title {"isLink":true,"level":2,"className":"text-lg font-semibold"} /-->
+      <!-- wp:shortcode -->[event_dates]<!-- /wp:shortcode -->
+      <!-- wp:shortcode -->[free_badge]<!-- /wp:shortcode -->
+    </div>
+    <!-- /wp:group -->
+  </article>
+  <!-- /wp:group -->
   <!-- /wp:post-template -->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- add helper shortcodes for event dates and free badge
- build Play Again presentation layout with Tailwind blocks

## Testing
- `composer lint`
- `npm run lint`
- ⚠️ `docker compose run --rm tests composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807c37ebf08329807df2a967e8a408