### PR TITLE
Add play again event content template

### DIFF
--- a/generations/third/newmr-theme/templates/play-again-event-content.php
+++ b/generations/third/newmr-theme/templates/play-again-event-content.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Table listing event presentations for replay.
+ *
+ * @package NewMR
+ */
+
+$event         = get_post();
+$presentations = new WP_Query(
+	array(
+		'connected_type'  => 'presentation_to_event',
+		'connected_items' => $event,
+		'nopaging'        => true,
+	)
+);
+if ( $presentations->have_posts() ) :
+	?>
+<div class="mx-auto max-w-4xl pb-8">
+		<table class="min-w-full divide-y divide-gray-200 border border-gray-200">
+				<thead class="bg-gray-50">
+						<tr>
+								<th scope="col" class="px-4 py-2 text-left text-sm font-semibold text-gray-900">Title</th>
+								<th scope="col" class="px-4 py-2 text-center text-sm font-semibold text-gray-900">Watch</th>
+								<th scope="col" class="px-4 py-2 text-center text-sm font-semibold text-gray-900">Slides</th>
+						</tr>
+				</thead>
+				<tbody class="divide-y divide-gray-200">
+	<?php
+	while ( $presentations->have_posts() ) :
+			$presentations->the_post();
+			$slides    = get_post_meta( get_the_ID(), 'presentation_slides', true );
+			$has_video = strlen( get_the_content() ) > 0;
+		?>
+						<tr>
+								<td class="px-4 py-2">
+										<a class="font-medium text-blue-700 hover:underline" href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+								</td>
+								<td class="px-4 py-2 text-center">
+									<?php if ( $has_video ) : ?>
+										<a href="<?php the_permalink(); ?>" class="text-blue-600 hover:underline">Watch</a>
+										<?php endif; ?>
+								</td>
+								<td class="px-4 py-2 text-center">
+									<?php if ( $slides ) : ?>
+										<a href="<?php echo esc_url( $slides ); ?>" class="text-blue-600 hover:underline">Download</a>
+										<?php endif; ?>
+								</td>
+						</tr>
+				<?php
+		endwhile;
+		wp_reset_postdata();
+	?>
+				</tbody>
+		</table>
+</div>
+	<?php
+endif;
+?>

--- a/generations/third/newmr-theme/templates/play-again-event.html
+++ b/generations/third/newmr-theme/templates/play-again-event.html
@@ -1,10 +1,8 @@
-<!-- wp:group {"tagName":"main","className":"py-8"} -->
-<main id="content" class="py-8">
-  <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
-  <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
-  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
-  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
-  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
-  <!-- /wp:post-template -->
-</main>
+<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
+<article class="prose mx-auto py-8">
+  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
+  <!-- wp:post-content /-->
+</article>
 <!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"play-again-event-content"} /-->


### PR DESCRIPTION
## Summary
- implement `play-again-event.html` to display event replays
- add new PHP template part for replay table using Tailwind styles

## Testing
- `composer lint`
- `npm run lint`
- `docker compose run --rm tests composer test` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68807c2dc4e08329b7807b0a5a31eb99