### PR TITLE
Enable Tailwind build in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `pull-production-data.sh` helper expects environment variables such as
 production database and sync the `wp-content/uploads` directory.
 
 ## Building the Theme
-Run `npm install` inside `generations/third/newmr-theme` and then `npm run build` to compile the Tailwind styles with Vite. Use `npm run watch` during development. The compiled CSS in `dist/style.css` is excluded from version control.
+Run `npm install` inside `generations/third/newmr-theme` and then `npm run build` to compile the Tailwind styles with Vite. During development start the `assets` service with `docker compose up assets` to automatically rebuild the CSS when files change. The compiled CSS in `dist/style.css` is excluded from version control.
 
 ## Tailwind UI Resources
 The repository includes a licensed copy of [Tailwind UI](https://tailwindui.com) under the `tailwindui/` directory. These components and templates are used for the third-generation UI. See `generations/third/TailwindUI.md` for usage instructions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,15 @@ services:
       - ./generations/third/newmr-theme:/var/www/html/wp-content/themes/newmr-theme
       - ./generations/third/newmr-plugin:/var/www/html/wp-content/plugins/newmr-plugin
 
+  assets:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: >-
+      sh -c "npm install --prefix generations/third/newmr-theme && \
+      npm run --prefix generations/third/newmr-theme watch"
+
   tests:
     build:
       context: .

--- a/generations/third/README.md
+++ b/generations/third/README.md
@@ -17,9 +17,11 @@ npm install --prefix newmr-theme
 docker compose run --rm tests composer test
 # Running the tests via Docker ensures consistent PHP and MySQL versions
 npm run --prefix newmr-theme build
+docker compose up assets # rebuild theme CSS on changes
 ```
 
-The theme assets can be rebuilt during development with `npm run --prefix newmr-theme watch`.
+The `assets` service uses Vite and Tailwind to watch the theme files and update
+`dist/style.css` automatically.
 
 ## Porting Checklist
 

--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -11,7 +11,24 @@
 function newmr_theme_setup() {
 	add_theme_support( 'wp-block-styles' );
 }
+
 add_action( 'after_setup_theme', 'newmr_theme_setup' );
+
+/**
+ * Enqueue the compiled Tailwind CSS if present.
+ */
+function newmr_enqueue_assets() {
+	$css = get_theme_file_path( 'dist/style.css' );
+	if ( file_exists( $css ) ) {
+		wp_enqueue_style(
+			'newmr-theme',
+			get_theme_file_uri( 'dist/style.css' ),
+			array(),
+			filemtime( $css )
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'newmr_enqueue_assets' );
 
 /**
  * Output the donate box content.

--- a/generations/third/newmr-theme/tailwind.config.js
+++ b/generations/third/newmr-theme/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  content: ['./templates/**/*.html', './*.php'],
+  content: [
+    './templates/**/*.{html,php}',
+    './*.php',
+    '../newmr-plugin/**/*.php',
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- watch Tailwind CSS in Docker using a new `assets` service
- load the compiled CSS if available
- update Tailwind config file scanning paths
- document the new workflow in READMEs

## Testing
- `npm run lint --prefix generations/third/newmr-theme`
- `composer lint`
- `npm run build --prefix generations/third/newmr-theme`


------
https://chatgpt.com/codex/tasks/task_b_688080d78d80832991bc02bcdefb7b37