### PR TITLE
Port person excerpt template

### DIFF
--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -75,3 +75,24 @@ add_shortcode( 'donate_box', 'donate_box' );
 add_shortcode( 'about_newmr_box', 'about_newmr_box' );
 add_shortcode( 'left_footer_link', 'left_footer_link' );
 add_shortcode( 'right_footer_link', 'right_footer_link' );
+
+/**
+ * Output the current person's company meta value.
+ *
+ * @return string
+ */
+function newmr_person_company() {
+	return '<span class="block text-sm text-gray-500">' . esc_html( get_post_meta( get_the_ID(), 'person_company', true ) ) . '</span>';
+}
+
+/**
+ * Output the current person's country meta value.
+ *
+ * @return string
+ */
+function newmr_person_country() {
+	return '<span class="block text-sm text-gray-500">' . esc_html( get_post_meta( get_the_ID(), 'person_country', true ) ) . '</span>';
+}
+
+add_shortcode( 'person_company', 'newmr_person_company' );
+add_shortcode( 'person_country', 'newmr_person_country' );

--- a/generations/third/newmr-theme/templates/excerpt-person.html
+++ b/generations/third/newmr-theme/templates/excerpt-person.html
@@ -1,6 +1,12 @@
-<!-- wp:group {"tagName":"article","className":"prose"} -->
-<article class="prose">
-  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
-  <!-- wp:post-excerpt /-->
+<!-- wp:group {"tagName":"article","className":"flex items-center gap-4"} -->
+<article class="flex items-center gap-4">
+  <!-- wp:post-featured-image {"isLink":true,"sizeSlug":"thumbnail","className":"w-24 h-24 rounded-full"} /-->
+  <!-- wp:group {"className":"flex-1"} -->
+  <div class="flex-1">
+    <!-- wp:post-title {"level":3,"isLink":true,"className":"font-semibold mb-1"} /-->
+    <!-- wp:shortcode -->[person_company]<!-- /wp:shortcode -->
+    <!-- wp:shortcode -->[person_country]<!-- /wp:shortcode -->
+  </div>
+  <!-- /wp:group -->
 </article>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- add Tailwind UI markup for person excerpts
- expose person_company and person_country shortcodes

## Testing
- `composer lint`
- `npm run lint`
- `docker compose run --rm tests composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807b6a02048329a6f31bffdfac984c