### PR TITLE
Implement pagination in index template

### DIFF
--- a/generations/third/newmr-theme/templates/index.html
+++ b/generations/third/newmr-theme/templates/index.html
@@ -1,10 +1,17 @@
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
+
+  <!-- wp:query {"query":{"inherit":true}} -->
   <!-- wp:post-template {"className":"space-y-12 max-w-2xl mx-auto"} -->
-  <!-- wp:post-title {"isLink":true,"className":"text-2xl font-semibold"} /-->
-  <!-- wp:post-excerpt {"className":"text-gray-700"} /-->
-  <!-- wp:post-date {"className":"text-sm text-gray-500"} /-->
+  <!-- wp:template-part {"slug":"excerpt"} /-->
   <!-- /wp:post-template -->
+
+  <!-- wp:query-pagination {"className":"mt-8 flex gap-x-2","layout":{"type":"flex","justifyContent":"space-between"}} -->
+  <!-- wp:query-pagination-previous {"className":"btn grow basis-0"} /-->
+  <!-- wp:query-pagination-numbers {"className":"hidden sm:flex items-baseline gap-x-2"} /-->
+  <!-- wp:query-pagination-next {"className":"btn flex grow basis-0 justify-end"} /-->
+  <!-- /wp:query-pagination -->
+  <!-- /wp:query -->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary
- enhance `index.html` in the third generation theme with a query loop
- reuse the `excerpt` template for post listings
- add Tailwind-styled query pagination controls

## Testing
- `npm run lint --prefix generations/third/newmr-theme`
- `composer lint`
- `composer test` *(fails: database connection)*

------
https://chatgpt.com/codex/tasks/task_b_68807c0155b88329a4a9b4a0aae4d61a