### PR TITLE
Add global header and footer includes

### DIFF
--- a/generations/third/newmr-theme/templates/404.html
+++ b/generations/third/newmr-theme/templates/404.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8 text-center space-y-6"} -->
 <main id="content" class="py-8 text-center space-y-6">
   <!-- wp:heading {"level":1,"className":"text-4xl"} -->
@@ -39,3 +40,4 @@
   </form>
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/archive-booth.html
+++ b/generations/third/newmr-theme/templates/archive-booth.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
@@ -10,3 +11,4 @@
   <!-- /wp:post-template -->
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/archive-person.html
+++ b/generations/third/newmr-theme/templates/archive-person.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
@@ -15,3 +16,4 @@
   <!-- /wp:post-template -->
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/front-page.php
+++ b/generations/third/newmr-theme/templates/front-page.php
@@ -1,3 +1,4 @@
+<?php get_header(); ?>
 <!-- wp:group {"tagName":"main","className":"py-8 space-y-12"} -->
 <main class="py-8 space-y-12">
   <!-- wp:query {"query":{"postType":"advert","metaKey":"advert_site","metaValue":"yes","orderBy":"menu_order","order":"asc"}} -->
@@ -30,3 +31,4 @@
   <!-- wp:shortcode -->[about_newmr_box]<!-- /wp:shortcode -->
 </main>
 <!-- /wp:group -->
+<?php get_footer(); ?>

--- a/generations/third/newmr-theme/templates/index.html
+++ b/generations/third/newmr-theme/templates/index.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
@@ -15,3 +16,4 @@
   <!-- /wp:query -->
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/page-events.html
+++ b/generations/third/newmr-theme/templates/page-events.html
@@ -1,6 +1,8 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8 space-y-12"} -->
 <main class="py-8 space-y-12">
   <!-- wp:post-title {"level":1,"className":"text-3xl font-bold text-center"} /-->
   <!-- wp:shortcode -->[events_page]<!-- /wp:shortcode -->
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/page.html
+++ b/generations/third/newmr-theme/templates/page.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
   <!-- wp:post-featured-image {"className":"rounded-lg mb-6"} /-->
@@ -7,3 +8,4 @@
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"comments"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/play-again-event.html
+++ b/generations/third/newmr-theme/templates/play-again-event.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
   <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
@@ -6,3 +7,4 @@
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"play-again-event-content"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/play-again-presentation.html
+++ b/generations/third/newmr-theme/templates/play-again-presentation.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"main","className":"py-8"} -->
 <main id="content" class="py-8">
   <!-- wp:query-title {"className":"text-3xl font-bold text-center mb-8"} /-->
@@ -17,3 +18,4 @@
   <!-- /wp:post-template -->
 </main>
 <!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/single-event.html
+++ b/generations/third/newmr-theme/templates/single-event.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
   <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
@@ -8,3 +9,4 @@
 
 <!-- wp:template-part {"slug":"sidebar-event"} /-->
 <!-- wp:template-part {"slug":"sidebar-presentation"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/single-person.html
+++ b/generations/third/newmr-theme/templates/single-person.html
@@ -1,78 +1,71 @@
-<?php
-$presentations = new WP_Query(
-    array(
-        'connected_type'  => 'presentation_to_person',
-        'connected_items' => get_post(),
-        'nopaging'        => true,
-    )
-);
-?>
+<!-- wp:template-part {"slug":"header"} /-->
+<?php $presentations = new WP_Query( array( 'connected_type' =>
+'presentation_to_person', 'connected_items' => get_post(), 'nopaging' => true, )
+); ?>
 
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
-    <header class="mb-6 text-center">
-        <?php the_post_thumbnail( 'medium', array( 'class' => 'mx-auto rounded-full mb-4' ) ); ?>
-        <!-- wp:post-title {"level":1,"className":"mb-2"} /-->
-        <div class="text-gray-600">
-            <span class="block"><?php echo esc_html( get_post_meta( get_the_ID(), 'person_company', true ) ); ?></span>
-            <span class="block"><?php echo esc_html( get_post_meta( get_the_ID(), 'person_country', true ) ); ?></span>
-        </div>
-    </header>
-    <section class="mb-8">
-        <h2 class="text-2xl font-semibold mb-4">Biography</h2>
-        <?php the_content(); ?>
-    </section>
+  <header class="mb-6 text-center">
+    <?php the_post_thumbnail( 'medium', array( 'class' => 'mx-auto rounded-full
+    mb-4' ) ); ?>
+    <!-- wp:post-title {"level":1,"className":"mb-2"} /-->
+    <div class="text-gray-600">
+      <span class="block"
+        ><?php echo esc_html( get_post_meta( get_the_ID(), 'person_company', true ) ); ?></span
+      >
+      <span class="block"
+        ><?php echo esc_html( get_post_meta( get_the_ID(), 'person_country', true ) ); ?></span
+      >
+    </div>
+  </header>
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">Biography</h2>
+    <?php the_content(); ?>
+  </section>
 </article>
 <!-- /wp:group -->
 
 <?php if ( $presentations->have_posts() ) : ?>
 <div class="presentations-list max-w-3xl mx-auto my-8">
-    <h2 class="text-xl font-semibold mb-4">Presentations</h2>
-    <table class="min-w-full divide-y divide-gray-200">
-        <thead>
-            <tr class="bg-gray-50">
-                <th class="speaker-col p-2 text-left">Speaker</th>
-                <th class="title-col p-2 text-left">Title</th>
-                <th class="watch-col p-2">Watch</th>
-                <th class="download-col p-2">Download Slides</th>
-            </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-            <?php
-            while ( $presentations->have_posts() ) :
-                $presentations->the_post();
-                $speakers = new WP_Query(
-                    array(
-                        'connected_type'  => 'presentation_to_person',
-                        'connected_items' => get_post(),
-                        'nopaging'        => true,
-                    )
-                );
-                $persons = array();
-                while ( $speakers->have_posts() ) {
-                    $speakers->the_post();
-                    $persons[] = '<a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
-                }
-                wp_reset_postdata();
-                ?>
-            <tr>
-                <td class="speaker-col p-2"><?php echo wp_kses_post( implode( ', ', $persons ) ); ?></td>
-                <td class="title-col p-2"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></td>
-                <td class="watch-col p-2"><a href="<?php the_permalink(); ?>">Watch</a></td>
-                <td class="download-col p-2">
-                    <?php
-                    $slides = get_post_meta( get_the_ID(), 'presentation_slides', true );
-                    if ( $slides ) :
-                        ?>
-                    <a href="<?php echo esc_url( $slides ); ?>">Download</a>
-                    <?php endif; ?>
-                </td>
-            </tr>
-            <?php endwhile; ?>
-        </tbody>
-    </table>
+  <h2 class="text-xl font-semibold mb-4">Presentations</h2>
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead>
+      <tr class="bg-gray-50">
+        <th class="speaker-col p-2 text-left">Speaker</th>
+        <th class="title-col p-2 text-left">Title</th>
+        <th class="watch-col p-2">Watch</th>
+        <th class="download-col p-2">Download Slides</th>
+      </tr>
+    </thead>
+    <tbody class="bg-white divide-y divide-gray-200">
+      <?php while ( $presentations->have_posts() ) : $presentations->the_post();
+      $speakers = new WP_Query( array( 'connected_type' =>
+      'presentation_to_person', 'connected_items' => get_post(), 'nopaging' =>
+      true, ) ); $persons = array(); while ( $speakers->have_posts() ) {
+      $speakers->the_post(); $persons[] = '<a
+        href="' . esc_url( get_permalink() ) . '"
+        >' . esc_html( get_the_title() ) . '</a
+      >'; } wp_reset_postdata(); ?>
+      <tr>
+        <td class="speaker-col p-2">
+          <?php echo wp_kses_post( implode( ', ', $persons ) ); ?>
+        </td>
+        <td class="title-col p-2">
+          <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+        </td>
+        <td class="watch-col p-2">
+          <a href="<?php the_permalink(); ?>">Watch</a>
+        </td>
+        <td class="download-col p-2">
+          <?php $slides = get_post_meta( get_the_ID(), 'presentation_slides',
+          true ); if ( $slides ) : ?>
+          <a href="<?php echo esc_url( $slides ); ?>">Download</a>
+          <?php endif; ?>
+        </td>
+      </tr>
+      <?php endwhile; ?>
+    </tbody>
+  </table>
 </div>
-<?php
-endif;
-wp_reset_postdata();
-?>
+<?php endif; wp_reset_postdata(); ?>
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/single-presentation.html
+++ b/generations/third/newmr-theme/templates/single-presentation.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
   <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
@@ -27,3 +28,4 @@
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"sidebar-presentation"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/generations/third/newmr-theme/templates/single.html
+++ b/generations/third/newmr-theme/templates/single.html
@@ -1,3 +1,4 @@
+<!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
 <article class="prose mx-auto py-8">
   <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
@@ -20,3 +21,4 @@
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"comments"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- ensure every template includes the header and footer
- call `get_header()` and `get_footer()` in `front-page.php`

## Testing
- `composer lint` *(fails: phpcs -q returned error code 2)*
- `docker compose run --rm tests composer test` *(fails: `docker` not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68808e6f9754832992c36c9f0e72d101