### PR TITLE
Add setup script for NewMR options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ The `pull-production-data.sh` helper expects environment variables such as
 `PROD_HOST`, `PROD_DB_NAME`, and `PROD_WP_PATH`. It uses SSH to dump the
 production database and sync the `wp-content/uploads` directory.
 
+## Automated Setup
+
+Use `scripts/set-newmr-options.sh` to configure the NewMR options via WP-CLI.
+Set the following environment variables before running the script:
+
+- `DONATE_BOX_HTML` – HTML for the Donate widget
+- `ABOUT_BOX_HTML` – HTML for the About widget
+- `GA_CODE` – Google Analytics tracking ID
+- `LEFT_PAGE_SLUG` – Slug for the left footer link
+- `RIGHT_PAGE_SLUG` – Slug for the right footer link
+- `FEATURED_VIDEO_SLUG` – Slug for the featured video page
+
+Run the script inside the `wpcli` container:
+
+```bash
+docker compose run --rm wpcli scripts/set-newmr-options.sh
+```
+
+The command is idempotent; running it multiple times will update the same
+options without creating duplicates.
+
 ## Building the Theme
 Run `npm install` inside `generations/third/newmr-theme` and then `npm run build` to compile the Tailwind styles with Vite. During development start the `assets` service with `docker compose up assets` to automatically rebuild the CSS when files change. The compiled CSS in `dist/style.css` is excluded from version control.
 

--- a/scripts/set-newmr-options.sh
+++ b/scripts/set-newmr-options.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Environment variables:
+#   DONATE_BOX_HTML      - HTML for the Donate widget (required)
+#   ABOUT_BOX_HTML       - HTML for the About widget (required)
+#   GA_CODE              - Google Analytics tracking ID (required)
+#   LEFT_PAGE_SLUG       - Slug for left footer link page (required)
+#   RIGHT_PAGE_SLUG      - Slug for right footer link page (required)
+#   FEATURED_VIDEO_SLUG  - Slug for featured video page (required)
+
+: "${DONATE_BOX_HTML:?DONATE_BOX_HTML is required}"
+: "${ABOUT_BOX_HTML:?ABOUT_BOX_HTML is required}"
+: "${GA_CODE:?GA_CODE is required}"
+: "${LEFT_PAGE_SLUG:?LEFT_PAGE_SLUG is required}"
+: "${RIGHT_PAGE_SLUG:?RIGHT_PAGE_SLUG is required}"
+: "${FEATURED_VIDEO_SLUG:?FEATURED_VIDEO_SLUG is required}"
+
+wp option update newmr_front_middle_left   "$DONATE_BOX_HTML"
+wp option update newmr_front_bottom_right "$ABOUT_BOX_HTML"
+wp option update newmr_ga_tracking_code   "$GA_CODE"
+wp option update newmr_left_footer_link   "$LEFT_PAGE_SLUG"
+wp option update newmr_right_footer_link  "$RIGHT_PAGE_SLUG"
+wp option update newmr_featured_video     "$FEATURED_VIDEO_SLUG"
+
+echo "NewMR options updated."


### PR DESCRIPTION
## Summary
- add `set-newmr-options.sh` for configuring WordPress options via WP‑CLI
- document the new script under a new **Automated Setup** section in README

## Testing
- `composer lint` *(fails: existing theme issues)*
- `docker compose run --rm tests composer test` *(fails: `docker` not found)*
- `npm run --prefix generations/third/newmr-theme lint` *(fails: code style issues in templates)*

------
https://chatgpt.com/codex/tasks/task_b_68808eee53848329a81eb1893c06b020