### PR TITLE
Improve presentation template structure

### DIFF
--- a/generations/third/newmr-theme/functions.php
+++ b/generations/third/newmr-theme/functions.php
@@ -260,7 +260,7 @@ function newmr_person_country_shortcode() {
 		return '<span class="block text-sm text-gray-500">' . esc_html( $country ) . '</span>';
 }
 add_shortcode( 'person_country', 'newmr_person_country_shortcode' );
-/** 
+/**
  * Output the current person's company meta value.
  *
  * @return string

--- a/generations/third/newmr-theme/index.php
+++ b/generations/third/newmr-theme/index.php
@@ -1,2 +1,10 @@
 <?php
-// Silence is golden. WordPress loads templates from /templates.
+/**
+ * Index file for security.
+ *
+ * WordPress loads templates from the templates directory.
+ *
+ * @package NewMR
+ */
+
+// Silence is golden.

--- a/generations/third/newmr-theme/templates/front-page.html
+++ b/generations/third/newmr-theme/templates/front-page.html
@@ -3,7 +3,7 @@
 <main class="py-8 space-y-12">
   <!-- wp:query {"query":{"postType":"advert","metaKey":"advert_site","metaValue":"yes","orderBy":"menu_order","order":"asc"}} -->
   <!-- wp:post-template {"className":"grid grid-cols-2 gap-4"} -->
-    <!-- wp:post-content /-->
+  <!-- wp:post-content /-->
   <!-- /wp:post-template -->
   <!-- /wp:query -->
 
@@ -11,20 +11,20 @@
 
   <!-- wp:query {"query":{"postType":"presentation","perPage":1,"orderBy":"rand"}} -->
   <!-- wp:post-template -->
-    <!-- wp:template-part {"slug":"slim-presentation"} /-->
+  <!-- wp:template-part {"slug":"slim-presentation"} /-->
   <!-- /wp:post-template -->
   <!-- /wp:query -->
 
   <!-- wp:query {"query":{"postType":"booth","perPage":1,"orderBy":"rand"}} -->
   <!-- wp:post-template -->
-    <!-- wp:post-content /-->
+  <!-- wp:post-content /-->
   <!-- /wp:post-template -->
   <!-- /wp:query -->
 
   <!-- wp:query {"query":{"postType":"post","perPage":1}} -->
   <!-- wp:post-template -->
-    <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
-    <!-- wp:post-excerpt /-->
+  <!-- wp:post-title {"level":2,"isLink":true,"className":"mb-2"} /-->
+  <!-- wp:post-excerpt /-->
   <!-- /wp:post-template -->
   <!-- /wp:query -->
 

--- a/generations/third/newmr-theme/templates/parts/related-presentations.php
+++ b/generations/third/newmr-theme/templates/parts/related-presentations.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Related presentations grid.
+ *
+ * @package NewMR
+ */
+
+$related = new WP_Query(
+	array(
+		'post_type'      => 'presentation',
+		'posts_per_page' => 3,
+		'post__not_in'   => array( get_the_ID() ),
+	)
+);
+
+if ( $related->have_posts() ) : ?>
+<div class="related-presentations grid grid-cols-1 sm:grid-cols-3 gap-6">
+	<?php
+	while ( $related->have_posts() ) :
+		$related->the_post();
+		?>
+<article class="shadow p-4 hover:shadow-lg transition">
+<a href="<?php the_permalink(); ?>" class="block hover:underline">
+		<?php the_title( '<h3 class="font-semibold mb-2">', '</h3>' ); ?>
+</a>
+</article>
+		<?php
+endwhile;
+	wp_reset_postdata();
+	?>
+</div>
+<?php endif; ?>

--- a/generations/third/newmr-theme/templates/parts/speaker-card.php
+++ b/generations/third/newmr-theme/templates/parts/speaker-card.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Speaker card partial.
+ *
+ * @package NewMR
+ */
+
+?>
+<article class="presenter flex items-center gap-3 mb-4">
+<?php the_post_thumbnail( array( 80, 80 ), array( 'class' => 'rounded-full' ) ); ?>
+<div>
+<h2 class="font-semibold text-lg mb-1"><?php the_title(); ?></h2>
+<?php
+$company = get_post_meta( get_the_ID(), 'person_company', true );
+if ( $company ) :
+	?>
+<span class="block text-sm text-gray-500"><?php echo esc_html( $company ); ?></span>
+<?php endif; ?>
+<?php
+$country = get_post_meta( get_the_ID(), 'person_country', true );
+if ( $country ) :
+	?>
+<span class="block text-sm text-gray-500"><?php echo esc_html( $country ); ?></span>
+<?php endif; ?>
+</div>
+</article>

--- a/generations/third/newmr-theme/templates/parts/video-embed.php
+++ b/generations/third/newmr-theme/templates/parts/video-embed.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Responsive video embed partial.
+ *
+ * @package NewMR
+ */
+
+$mp4  = get_post_meta( get_the_ID(), 'presentation_mp4file', true );
+$webm = get_post_meta( get_the_ID(), 'presentation_webmfile', true );
+$ogv  = get_post_meta( get_the_ID(), 'presentation_ogvfile', true );
+
+if ( $mp4 || $webm || $ogv ) : ?>
+<div class="aspect-w-16 aspect-h-9 mb-4">
+<video class="w-full rounded-lg" controls preload="auto" loading="lazy">
+	<?php if ( $mp4 ) : ?>
+<source src="<?php echo esc_url( $mp4 ); ?>" type="video/mp4" />
+	<?php endif; ?>
+	<?php if ( $webm ) : ?>
+<source src="<?php echo esc_url( $webm ); ?>" type="video/webm" />
+	<?php endif; ?>
+	<?php if ( $ogv ) : ?>
+<source src="<?php echo esc_url( $ogv ); ?>" type="video/ogg" />
+	<?php endif; ?>
+</video>
+</div>
+<?php endif; ?>

--- a/generations/third/newmr-theme/templates/sidebar-presentation.php
+++ b/generations/third/newmr-theme/templates/sidebar-presentation.php
@@ -13,25 +13,18 @@ $people = new WP_Query(
 	)
 );
 if ( $people->have_posts() ) : ?>
-<!-- wp:group {"tagName":"aside","className":"p-4 bg-gray-50"} -->
-<aside class="p-4 bg-gray-50" id="presenters">
+<!-- wp:group {"tagName":"aside","className":"p-4 bg-gray-50 hidden lg:block"} -->
+<aside class="p-4 bg-gray-50 hidden lg:block" id="presenters">
 	<?php
 	while ( $people->have_posts() ) :
 		$people->the_post();
-		?>
-	<div class="presenter flex items-center gap-3 mb-4">
-		<?php the_post_thumbnail( array( 80, 80 ) ); ?>
-	<div>
-		<h4 class="font-semibold"><?php the_title(); ?></h4>
-		<span class="block text-sm text-gray-500"><?php echo esc_html( get_post_meta( get_the_ID(), 'person_company', true ) ); ?></span>
-		<span class="block text-sm text-gray-500"><?php echo esc_html( get_post_meta( get_the_ID(), 'person_country', true ) ); ?></span>
-	</div>
-	</div>
-		<?php
-	endwhile;
+		get_template_part( 'parts/speaker-card' );
+endwhile;
 	wp_reset_postdata();
 	?>
 </aside>
 <!-- /wp:group -->
 <?php endif; ?>
+<aside class="hidden lg:block" aria-label="<?php esc_attr_e( 'Advertisement', 'newmr' ); ?>">
 <?php get_sidebar(); ?>
+</aside>

--- a/generations/third/newmr-theme/templates/single-presentation.html
+++ b/generations/third/newmr-theme/templates/single-presentation.html
@@ -1,31 +1,27 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:group {"tagName":"article","className":"prose mx-auto py-8"} -->
-<article class="prose mx-auto py-8">
-  <!-- wp:post-title {"level":1,"className":"mb-4"} /-->
-  <?php $content = get_the_content(); if ( strlen( trim( $content ) ) > 0 ) {
-  the_content(); } else { $mp4 = get_post_meta( get_the_ID(),
-  'presentation_mp4file', true ); $webm = get_post_meta( get_the_ID(),
-  'presentation_webmfile', true ); $ogv = get_post_meta( get_the_ID(),
-  'presentation_ogvfile', true ); if ( $mp4 || $webm || $ogv ) : ?>
-  <video class="w-full rounded-lg mb-4" controls preload="auto">
-    <?php if ( $mp4 ) : ?>
-    <source src="<?php echo esc_url( $mp4 ); ?>" type="video/mp4" />
-    <?php endif; ?> <?php if ( $webm ) : ?>
-    <source src="<?php echo esc_url( $webm ); ?>" type="video/webm" />
-    <?php endif; ?> <?php if ( $ogv ) : ?>
-    <source src="<?php echo esc_url( $ogv ); ?>" type="video/ogg" />
+<main id="content" class="prose mx-auto py-8">
+  <section aria-labelledby="presentation-title">
+    <h1 id="presentation-title" class="mb-4"><?php the_title(); ?></h1>
+    <?php $content = get_the_content(); if ( strlen( trim( $content ) ) > 0 ) {
+    the_content(); } else { get_template_part( 'parts/video-embed' ); } $slides
+    = get_post_meta( get_the_ID(), 'presentation_slides', true ); if ( $slides )
+    : ?>
+    <a href="<?php echo esc_url( $slides ); ?>" class="btn inline-block mt-4"
+      ><?php esc_html_e( 'Download Slides', 'newmr' ); ?></a
+    >
     <?php endif; ?>
-  </video>
-  <?php endif; } $slides = get_post_meta( get_the_ID(), 'presentation_slides',
-  true ); if ( $slides ) : ?>
-  <a
-    href="<?php echo esc_url( $slides ); ?>"
-    class="inline-block mt-4 bg-blue-600 text-white px-4 py-2 rounded"
-    ><?php esc_html_e( 'Download Slides', 'newmr' ); ?></a
+  </section>
+  <?php $people = new WP_Query( array( 'connected_type' =>
+  'presentation_to_person', 'connected_items' => get_post(), 'nopaging' => true,
+  ) ); if ( $people->have_posts() ) : ?>
+  <section
+    class="mt-6"
+    aria-label="<?php esc_attr_e( 'Speakers', 'newmr' ); ?>"
   >
+    <?php while ( $people->have_posts() ) : $people->the_post();
+    get_template_part( 'parts/speaker-card' ); endwhile; wp_reset_postdata(); ?>
+  </section>
   <?php endif; ?>
-</article>
-<!-- /wp:group -->
-
+</main>
 <!-- wp:template-part {"slug":"sidebar-presentation"} /-->
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- enhance single presentation layout
- add speaker card partial
- create responsive video and related presentations components
- make sidebar responsive and accessible
- fix coding standards issues

## Testing
- `composer lint`
- `npm run lint`
- `docker compose run --rm tests composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880a0c73ae88329aef7a2d137802625