### PR TITLE
Fix play again URL generation

### DIFF
--- a/generations/third/newmr-theme/templates/page-play-again.php
+++ b/generations/third/newmr-theme/templates/page-play-again.php
@@ -138,7 +138,7 @@ if ( isset( $wp_query->query_vars['one'] ) && '' !== $wp_query->query_vars['one'
 								<?php endif; ?>
 								<div>
 										<h2 class="text-xl font-semibold">
-												<a href="<?php echo esc_url( site_url( '/play-again/' . get_post()->post_name ) ); ?>" class="hover:underline">
+												<a href="<?php echo esc_url( home_url( '/play-again/' . get_post()->post_name ) ); ?>" class="hover:underline">
 														<?php the_title(); ?>
 												</a>
 										</h2>

--- a/generations/third/newmr-theme/templates/sidebar-event.php
+++ b/generations/third/newmr-theme/templates/sidebar-event.php
@@ -25,7 +25,7 @@ if ( $ready_count > 0 ) : ?>
 <!-- wp:group {"tagName":"aside","className":"p-4 bg-gray-50"} -->
 <aside class="p-4 bg-gray-50" id="play-again-sidebar">
 	<div id="sidebar-container">
-	<a href="<?php echo esc_url( get_site_url() . '/play-again/' . $e_post->post_name ); ?>" class="block">
+	<a href="<?php echo esc_url( home_url( '/play-again/' ) . $e_post->post_name ); ?>" class="block">
 		<h2 class="font-bold text-lg">Play Again</h2>
 				<span><?php echo intval( $pres->post_count ); ?> recording<?php echo 1 !== $pres->post_count ? 's' : ''; ?></span>
 	</a>


### PR DESCRIPTION
## Summary
- ensure play-again sidebar link uses `home_url`
- fix play-again page links to also use `home_url`

## Testing
- `composer lint`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6880ad9f62cc8329b13561636167bb94