### PR TITLE
Fix search template localization

### DIFF
--- a/generations/third/newmr-theme/templates/search.php
+++ b/generations/third/newmr-theme/templates/search.php
@@ -32,7 +32,7 @@ if ( have_posts() ) :
 	<header class="mb-6">
 		<h1 class="text-3xl font-bold">
 	<?php
-	esc_html_e( 'Search results for: ' );
+		esc_html_e( 'Search results for: ', 'newmr-theme' );
 	echo esc_html( get_search_query() );
 	?>
 		</h1>
@@ -143,7 +143,7 @@ if ( have_posts() ) :
 		<?php endif; ?>
 	</article>
 <?php else : ?>
-	<h2><?php esc_html_e( 'No results' ); ?></h2>
+		<h2><?php esc_html_e( 'No results', 'newmr-theme' ); ?></h2>
 <?php endif; ?>
 	</main>
 </section>


### PR DESCRIPTION
## Summary
- add missing textdomain arguments in search.php

## Testing
- `composer lint`
- `npm run lint`
- `docker compose run --rm tests composer test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880adb53e6883299f20bd3091eca048